### PR TITLE
Getrid of realpath

### DIFF
--- a/jmxexporter-prometheus-grafana/assets/prometheus/prometheus-config/prometheus.yml
+++ b/jmxexporter-prometheus-grafana/assets/prometheus/prometheus-config/prometheus.yml
@@ -37,19 +37,21 @@ scrape_configs:
       labels:
         env: 'dev'
 
-  - job_name: 'producer'
-    static_configs:
-      - targets:
-          - 'producer:1234'
-        labels:
-          env: 'dev'
+# No producer for the moment in cp-demo
+#  - job_name: 'producer'
+#    static_configs:
+#      - targets:
+#          - 'producer:1234'
+#        labels:
+#          env: 'dev'
 
-  - job_name: 'consumer'
-    static_configs:
-      - targets:
-          - "consumer:1234"
-        labels:
-          env: 'dev'
+# No consumer for the moment in cp-demo
+#  - job_name: 'consumer'
+#    static_configs:
+#      - targets:
+#          - "consumer:1234"
+#        labels:
+#          env: 'dev'
 
   - job_name: 'kafka-lag-exporter'
     static_configs:

--- a/jmxexporter-prometheus-grafana/assets/prometheus/prometheus-config/prometheus.yml
+++ b/jmxexporter-prometheus-grafana/assets/prometheus/prometheus-config/prometheus.yml
@@ -1,6 +1,7 @@
 global:
-  scrape_interval:     15s # By default, scrape targets every 15 seconds.
+  scrape_interval:     60s # By default, scrape targets every 15 seconds.
   evaluation_interval: 15s # By default, scrape targets every 15 seconds.
+  scrape_timeout: 30s 
 
 rule_files:
   - 'alert.rules'

--- a/jmxexporter-prometheus-grafana/assets/prometheus/prometheus-config/prometheus.yml
+++ b/jmxexporter-prometheus-grafana/assets/prometheus/prometheus-config/prometheus.yml
@@ -1,7 +1,7 @@
 global:
   scrape_interval:     60s # By default, scrape targets every 15 seconds.
   evaluation_interval: 15s # By default, scrape targets every 15 seconds.
-  scrape_timeout: 30s 
+  scrape_timeout: 30s # By default, scrape timeout is 10 seconds. But cp-demo is using cpu throttling, so let's leave enough time to fetch the metrics in particular for the first time as it needs to compile all rexps.
 
 rule_files:
   - 'alert.rules'

--- a/jmxexporter-prometheus-grafana/assets/prometheus/prometheus-config/prometheus.yml
+++ b/jmxexporter-prometheus-grafana/assets/prometheus/prometheus-config/prometheus.yml
@@ -1,7 +1,14 @@
 global:
-  scrape_interval:     60s # By default, scrape targets every 15 seconds.
-  evaluation_interval: 15s # By default, scrape targets every 15 seconds.
-  scrape_timeout: 30s # By default, scrape timeout is 10 seconds. But cp-demo is using cpu throttling, so let's leave enough time to fetch the metrics in particular for the first time as it needs to compile all rexps.
+  # How frequently to scrape targets by default.
+  # Default 15s
+  scrape_interval:     60s
+  # How frequently to evaluate rules.
+  # Default 15s
+  evaluation_interval: 15s
+  # How long until a scrape request times out.
+  # Default to 10s.
+  # Required because cp-demo is using cpu throttling, so let's leave enough time to fetch the metrics in particular for the first time as it needs to compile all rexps
+  scrape_timeout: 30s
 
 rule_files:
   - 'alert.rules'

--- a/jmxexporter-prometheus-grafana/start.sh
+++ b/jmxexporter-prometheus-grafana/start.sh
@@ -12,6 +12,7 @@ echo -e "Launch cp-demo in $CP_DEMO_HOME (version $CP_DEMO_VERSION) and monitori
 (cd $CP_DEMO_HOME && ./scripts/start.sh)
 
 
+
 ########################################
 # Start monitoring solution
 ########################################

--- a/utils/setup_cp_demo.sh
+++ b/utils/setup_cp_demo.sh
@@ -1,6 +1,13 @@
 #!/bin/bash
 
-DEFAULT_CP_DEMO_HOME=$(realpath ${MONITORING_STACK}/../../cp-demo)
+fullpath ()
+{
+   fullpath=$(cd $1 && pwd -P)
+   echo $fullpath
+   cd $OLDPWD
+}
+
+DEFAULT_CP_DEMO_HOME=$(fullpath ${MONITORING_STACK}/../../cp-demo)
 CP_DEMO_HOME=${CP_DEMO_HOME:-$DEFAULT_CP_DEMO_HOME}
 
 [ -d "${CP_DEMO_HOME}" ] || {

--- a/utils/setup_cp_demo.sh
+++ b/utils/setup_cp_demo.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+# This method does a job similar to realpath, but avoid that extra dependency.
+# It returns fullpath for a given parameter to avoind using relative paths.
 fullpath ()
 {
    fullpath=$(cd $1 && pwd -P)


### PR DESCRIPTION
This PR removes realpath dependency by using a bash native function doing the same job.

It also add some buffer on scrape_timeout so we can scrape more easily.
To get some background the first time prometheus will fetch the metric it will need to evaluate all jmx-metrics and compile the regexp which can be a CPU hit at first.
Because cp-demo is throttling cpu with the "cpu: 0.7" directive in the docker-compose it's not able answer fast enough with the default prometheus scrape timeout (10s).
Here we just increased the buffer to leave time to fetch (in particular for the first time)