### PR TITLE
Set Zookeeper Grafana dashboard datasource to Prometheus

### DIFF
--- a/jmxexporter-prometheus-grafana/assets/prometheus/grafana/provisioning/dashboards/zookeeper-overview.json
+++ b/jmxexporter-prometheus-grafana/assets/prometheus/grafana/provisioning/dashboards/zookeeper-overview.json
@@ -1199,4 +1199,5 @@
   "timezone": "",
   "title": "Zookeeper Overview",
   "uid": "H4xS98vWk",
+  "version": 4
 }

--- a/jmxexporter-prometheus-grafana/assets/prometheus/grafana/provisioning/dashboards/zookeeper-overview.json
+++ b/jmxexporter-prometheus-grafana/assets/prometheus/grafana/provisioning/dashboards/zookeeper-overview.json
@@ -439,7 +439,7 @@
         "rgba(237, 129, 40, 0.89)",
         "#d44a3a"
       ],
-      "datasource": null,
+      "datasource": "Prometheus",
       "description": "Number of Watchers",
       "fieldConfig": {
         "defaults": {
@@ -1199,5 +1199,4 @@
   "timezone": "",
   "title": "Zookeeper Overview",
   "uid": "H4xS98vWk",
-  "version": 2
 }

--- a/jmxexporter-prometheus-grafana/assets/prometheus/grafana/provisioning/dashboards/zookeeper-overview.json
+++ b/jmxexporter-prometheus-grafana/assets/prometheus/grafana/provisioning/dashboards/zookeeper-overview.json
@@ -22,8 +22,12 @@
       "cacheTimeout": null,
       "colorBackground": false,
       "colorValue": true,
-      "colors": ["#d44a3a", "rgba(237, 129, 40, 0.89)", "#299c46"],
-      "datasource": null,
+      "colors": [
+        "#d44a3a",
+        "rgba(237, 129, 40, 0.89)",
+        "#299c46"
+      ],
+      "datasource": "Prometheus",
       "description": "Quorum Size of Zookeeper ensemble",
       "fieldConfig": {
         "defaults": {
@@ -109,8 +113,12 @@
       "cacheTimeout": null,
       "colorBackground": false,
       "colorValue": true,
-      "colors": ["#299c46", "rgba(237, 129, 40, 0.89)", "#d44a3a"],
-      "datasource": null,
+      "colors": [
+        "#299c46",
+        "rgba(237, 129, 40, 0.89)",
+        "#d44a3a"
+      ],
+      "datasource": "Prometheus",
       "description": "Number of Alive Connections",
       "fieldConfig": {
         "defaults": {
@@ -198,14 +206,20 @@
         "conditions": [
           {
             "evaluator": {
-              "params": [10],
+              "params": [
+                10
+              ],
               "type": "gt"
             },
             "operator": {
               "type": "and"
             },
             "query": {
-              "params": ["A", "5m", "now"]
+              "params": [
+                "A",
+                "5m",
+                "now"
+              ]
             },
             "reducer": {
               "params": [],
@@ -226,7 +240,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "Prometheus",
       "description": "Number of queued requests in the server. This goes up when the server receives more requests than it can process",
       "fieldConfig": {
         "defaults": {
@@ -329,8 +343,12 @@
       "cacheTimeout": null,
       "colorBackground": false,
       "colorValue": true,
-      "colors": ["#299c46", "rgba(237, 129, 40, 0.89)", "#d44a3a"],
-      "datasource": null,
+      "colors": [
+        "#299c46",
+        "rgba(237, 129, 40, 0.89)",
+        "#d44a3a"
+      ],
+      "datasource": "Prometheus",
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -416,7 +434,11 @@
       "cacheTimeout": null,
       "colorBackground": false,
       "colorValue": true,
-      "colors": ["#299c46", "rgba(237, 129, 40, 0.89)", "#d44a3a"],
+      "colors": [
+        "#299c46",
+        "rgba(237, 129, 40, 0.89)",
+        "#d44a3a"
+      ],
       "datasource": null,
       "description": "Number of Watchers",
       "fieldConfig": {
@@ -504,7 +526,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "Prometheus",
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -598,7 +620,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "Prometheus",
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -692,7 +714,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "Prometheus",
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -786,7 +808,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "Prometheus",
       "description": "Amount of time it takes for the server to respond to a client request",
       "fieldConfig": {
         "defaults": {
@@ -881,14 +903,20 @@
         "conditions": [
           {
             "evaluator": {
-              "params": [10],
+              "params": [
+                10
+              ],
               "type": "gt"
             },
             "operator": {
               "type": "and"
             },
             "query": {
-              "params": ["A", "5m", "now"]
+              "params": [
+                "A",
+                "5m",
+                "now"
+              ]
             },
             "reducer": {
               "params": [],
@@ -909,7 +937,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "Prometheus",
       "description": "Amount of time it takes for the server to respond to a client request",
       "fieldConfig": {
         "defaults": {
@@ -1012,14 +1040,20 @@
         "conditions": [
           {
             "evaluator": {
-              "params": [20],
+              "params": [
+                20
+              ],
               "type": "gt"
             },
             "operator": {
               "type": "and"
             },
             "query": {
-              "params": ["A", "5m", "now"]
+              "params": [
+                "A",
+                "5m",
+                "now"
+              ]
             },
             "reducer": {
               "params": [],
@@ -1040,7 +1074,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "Prometheus",
       "description": "Amount of time it takes for the server to respond to a client request",
       "fieldConfig": {
         "defaults": {


### PR DESCRIPTION
Zookeeper dashboard datasource is empty, and points to default ds. This won't work on Grafana deployments where there are other default datasources.