### PR TITLE
Convert KAFKA_OPTS to EXTRA_ARGS to allow kafka cli compatibility

### DIFF
--- a/jmxexporter-prometheus-grafana/docker-compose.override.yml
+++ b/jmxexporter-prometheus-grafana/docker-compose.override.yml
@@ -10,21 +10,13 @@ services:
     volumes:
       - $MONITORING_STACK/assets/prometheus/jmx-exporter/:/usr/share/jmx-exporter
     environment:
-      KAFKA_OPTS:
-        -Djava.security.auth.login.config=/etc/kafka/secrets/broker_jaas.conf
-        -Djavax.net.ssl.trustStore=/etc/kafka/secrets/kafka.kafka1.truststore.jks
-        -Djavax.net.ssl.trustStorePassword=confluent
-        -javaagent:/usr/share/jmx-exporter/jmx_prometheus_javaagent-0.12.0.jar=1234:/usr/share/jmx-exporter/kafka_broker.yml
+      EXTRA_ARGS: -javaagent:/usr/share/jmx-exporter/jmx_prometheus_javaagent-0.12.0.jar=1234:/usr/share/jmx-exporter/kafka_broker.yml
 
   kafka2:
     volumes:
       - $MONITORING_STACK/assets/prometheus/jmx-exporter/:/usr/share/jmx-exporter
     environment:
-      KAFKA_OPTS:
-        -Djava.security.auth.login.config=/etc/kafka/secrets/broker_jaas.conf
-        -Djavax.net.ssl.trustStore=/etc/kafka/secrets/kafka.kafka2.truststore.jks
-        -Djavax.net.ssl.trustStorePassword=confluent
-        -javaagent:/usr/share/jmx-exporter/jmx_prometheus_javaagent-0.12.0.jar=1234:/usr/share/jmx-exporter/kafka_broker.yml
+      EXTRA_ARGS: -javaagent:/usr/share/jmx-exporter/jmx_prometheus_javaagent-0.12.0.jar=1234:/usr/share/jmx-exporter/kafka_broker.yml
 
   streams-demo:
     volumes:
@@ -36,13 +28,13 @@ services:
     volumes:
       - $MONITORING_STACK/assets/prometheus/jmx-exporter/:/usr/share/jmx-exporter
     environment:
-      KAFKA_OPTS: -javaagent:/usr/share/jmx-exporter/jmx_prometheus_javaagent-0.12.0.jar=1234:/usr/share/jmx-exporter/kafka_connect.yml
+      EXTRA_ARGS: -javaagent:/usr/share/jmx-exporter/jmx_prometheus_javaagent-0.12.0.jar=1234:/usr/share/jmx-exporter/kafka_connect.yml
 
   schemaregistry:
     volumes:
       - $MONITORING_STACK/assets/prometheus/jmx-exporter/:/usr/share/jmx-exporter
     environment:
-      SCHEMA_REGISTRY_OPTS: -javaagent:/usr/share/jmx-exporter/jmx_prometheus_javaagent-0.12.0.jar=1234:/usr/share/jmx-exporter/confluent_schemaregistry.yml
+      EXTRA_ARGS: -javaagent:/usr/share/jmx-exporter/jmx_prometheus_javaagent-0.12.0.jar=1234:/usr/share/jmx-exporter/confluent_schemaregistry.yml
 
   ksqldb-server:
     volumes:

--- a/jolokia-elastic-kibana/docker-compose.override.yml
+++ b/jolokia-elastic-kibana/docker-compose.override.yml
@@ -12,32 +12,19 @@ services:
     volumes:
       - $MONITORING_STACK/assets/jolokia-jvm-1.6.2-agent.jar:/tmp/jolokia/jolokia-jvm-1.6.2-agent.jar:rw
     environment:
-      KAFKA_OPTS:
-        -Djava.security.auth.login.config=/etc/kafka/secrets/broker_jaas.conf
-        -Djavax.net.ssl.trustStore=/etc/kafka/secrets/kafka.kafka1.truststore.jks
-        -Djavax.net.ssl.trustStorePassword=confluent
-        -javaagent:/tmp/jolokia/jolokia-jvm-1.6.2-agent.jar=port=49900,host=*
+      EXTRA_ARGS: -javaagent:/tmp/jolokia/jolokia-jvm-1.6.2-agent.jar=port=49900,host=*
 
   kafka2:
     volumes:
       - $MONITORING_STACK/assets/jolokia-jvm-1.6.2-agent.jar:/tmp/jolokia/jolokia-jvm-1.6.2-agent.jar:rw
     environment:
-      KAFKA_OPTS:
-        -Djava.security.auth.login.config=/etc/kafka/secrets/broker_jaas.conf
-        -Djavax.net.ssl.trustStore=/etc/kafka/secrets/kafka.kafka2.truststore.jks
-        -Djavax.net.ssl.trustStorePassword=confluent
-        -javaagent:/tmp/jolokia/jolokia-jvm-1.6.2-agent.jar=port=49900,host=*
+      EXTRA_ARGS: -javaagent:/tmp/jolokia/jolokia-jvm-1.6.2-agent.jar=port=49900,host=*
 
   connect:
     volumes:
       - $MONITORING_STACK/assets/jolokia-jvm-1.6.2-agent.jar:/tmp/jolokia/jolokia-jvm-1.6.2-agent.jar:rw
     environment:
-      KAFKA_OPTS:
-        -Djavax.net.ssl.trustStore=/etc/kafka/secrets/kafka.connect.truststore.jks
-        -Djavax.net.ssl.trustStorePassword=confluent
-        -Djavax.net.ssl.keyStore=/etc/kafka/secrets/kafka.connect.keystore.jks
-        -Djavax.net.ssl.keyStorePassword=confluent
-        -javaagent:/tmp/jolokia/jolokia-jvm-1.6.2-agent.jar=port=49900,host=*
+      EXTRA_ARGS: -javaagent:/tmp/jolokia/jolokia-jvm-1.6.2-agent.jar=port=49900,host=*
 
   elasticsearch:
     cpus: 0.8


### PR DESCRIPTION
This patch is to resolve issues with the "address in use" problem arising due to recent changes in the cp-demo package. 
Recent changes in cp-demo moved the topic creation script from additional containers to Kafka containers which would not allow CLI execution as these tools will reference the KAFKA_OPTS and try instrumenting JMX exporter/Jolokia on the same port already used. 

The fix moves the -javaagent switch from KAFKA_OPTS to EXTRA_ARGS to prevent those issues. 