### PR TITLE
Add missing instance label

### DIFF
--- a/jmxexporter-prometheus-grafana/assets/prometheus/grafana/provisioning/dashboards/connect-overview.json
+++ b/jmxexporter-prometheus-grafana/assets/prometheus/grafana/provisioning/dashboards/connect-overview.json
@@ -1013,7 +1013,7 @@
           "refId": "A"
         },
         {
-          "expr": "jvm_memory_bytes_max{job=\"connect\",env=\"$env\",cluster=~\"$cluster\",area=\"heap\"}",
+          "expr": "jvm_memory_bytes_max{job=\"connect\",env=\"$env\",cluster=~\"$cluster\",instance=~\"$instance\",area=\"heap\"}",
           "interval": "",
           "legendFormat": "{{instance}}",
           "refId": "B"


### PR DESCRIPTION
This PR added a missing `instance` label in Kafka Connect dashboard.