### PR TITLE
Metrics Fetch Optimization for Kafka Broker

### DIFF
--- a/shared-assets/jmx-exporter/kafka_broker.yml
+++ b/shared-assets/jmx-exporter/kafka_broker.yml
@@ -1,69 +1,172 @@
+---
+startDelaySeconds: 120
 lowercaseOutputName: true
+lowercaseOutputLabelNames: true
+blacklistObjectNames:
+  - "kafka.consumer:type=*,id=*"
+  - "kafka.consumer:type=*,client-id=*"
+  - "kafka.consumer:type=*,client-id=*,node-id=*"
+  - "kafka.producer:type=*,id=*"
+  - "kafka.producer:type=*,client-id=*"
+  - "kafka.producer:type=*,client-id=*,node-id=*"
+  - "kafka.*:type=kafka-metrics-count,*"
+  # This will ignore the admin client metrics from Kafka Brokers and will blacklist certain metrics
+  # that do not make sense for ingestion.
+  # "kafka.admin.client:type=*, node-id=*, client-id=*"
+  # "kafka.admin.client:type=*, client-id=*"
+  # "kafka.admin.client:type=*, id=*"
+  - "kafka.admin.client:*"
+  - "kafka.server:type=*,cipher=*,protocol=*,listener=*,networkProcessor=*"
+  - "kafka.server:type=*"
 rules:
-# Special cases and very specific rules
-- pattern : kafka.server<type=(.+), name=(.+), clientId=(.+), topic=(.+), partition=(.*)><>Value
-  name: kafka_server_$1_$2
-  type: GAUGE
-  labels:
-    clientId: "$3"
-    topic: "$4"
-    partition: "$5"
-- pattern : kafka.server<type=(.+), name=(.+), clientId=(.+), brokerHost=(.+), brokerPort=(.+)><>Value
-  name: kafka_server_$1_$2
-  type: GAUGE
-  labels:
-    clientId: "$3"
-    broker: "$4:$5"
+  # This is by far the biggest contributor to the number of sheer metrics being produced.
+  # Always keep it on the top for the case of probability when so many metrics will hit the first condition and exit.
+  # "kafka.cluster:type=*, name=*, topic=*, partition=*"
+  # "kafka.log:type=*,name=*, topic=*, partition=*"
+  - pattern: kafka.(\w+)<type=(.+), name=(.+), topic=(.+), partition=(.+)><>Value
+    name: kafka_$1_$2_$3
+    type: GAUGE
+    labels:
+      topic: "$4"
+      partition: "$5"
+  # "kafka.server:type=*,name=*, client-id=*, topic=*, partition=*"
+  - pattern: kafka.server<type=(.+), name=(.+), clientId=(.+), topic=(.+), partition=(.*)><>Value
+    name: kafka_server_$1_$2
+    type: GAUGE
+    labels:
+      clientId: "$3"
+      topic: "$4"
+      partition: "$5"
+  - pattern: kafka.server<type=(.+), name=(.+), clientId=(.+), brokerHost=(.+), brokerPort=(.+)><>Value
+    name: kafka_server_$1_$2
+    type: GAUGE
+    labels:
+      clientId: "$3"
+      broker: "$4:$5"
+  # "kafka.network:type=*, name=*, request=*, error=*"
+  # "kafka.network:type=*, name=*, request=*, version=*"
+  - pattern: kafka.(\w+)<type=(.+), name=(.+), (.+)=(.+), (.+)=(.+)><>(Count|Value)
+    name: kafka_$1_$2_$3
+    labels:
+      "$4": "$5"
+      "$6": "$7"
+  - pattern: kafka.(\w+)<type=(.+), name=(.+), (.+)=(.*), (.+)=(.+)><>(\d+)thPercentile
+    name: kafka_$1_$2_$3
+    type: GAUGE
+    labels:
+      "$4": "$5"
+      "$6": "$7"
+      quantile: "0.$8"
+  # "kafka.rest:type=*, topic=*, partition=*, client-id=*"
+  # "kafka.rest:type=*, cipher=*, protocol=*, client-id=*"
+  - pattern: kafka.(\w+)<type=(.+), (.+)=(.+), (.+)=(.+), (.+)=(.+)><>Value
+    name: kafka_$1_$2
+    labels:
+      "$3": "$4"
+      "$5": "$6"
+      "$7": "$8"
+  # Count and Value
+  # "kafka.server:type=*, name=*, topic=*"
+  # "kafka.server:type=*, name=*, clientId=*"
+  # "kafka.server:type=*, name=*, delayedOperation=*"
+  # "kafka.server:type=*, name=*, fetcherType=*"
+  # "kafka.network:type=*, name=*, networkProcessor=*"
+  # "kafka.network:type=*, name=*, processor=*"
+  # "kafka.network:type=*, name=*, request=*"
+  # "kafka.network:type=*, name=*, listener=*"
+  # "kafka.log:type=*, name=*, logDirectory=*"
+  # "kafka.log:type=*, name=*, op=*"
+  # "kafka.rest:type=*, node-id=*, client-id=*"
+  - pattern: kafka.(\w+)<type=(.+), name=(.+), (.+)=(.+)><>(Count|Value)
+    name: kafka_$1_$2_$3
+    labels:
+      "$4": "$5"
+  # "kafka.consumer:type=*, topic=*, client-id=*"
+  # "kafka.producer:type=*, topic=*, client-id=*"
+  # "kafka.rest:type=*, topic=*, client-id=*"
+  # "kafka.server:type=*, broker-id=*, fetcher-id=*"
+  # "kafka.server:type=*, listener=*, networkProcessor=*"
+  - pattern: kafka.(\w+)<type=(.+), (.+)=(.+), (.+)=(.+)><>(Count|Value)
+    name: kafka_$1_$2
+    labels:
+      "$3": "$4"
+      "$5": "$6"
+  # "kafka.network:type=*, name=*"
+  # "kafka.server:type=*, name=*"
+  # "kafka.controller:type=*, name=*"
+  # "kafka.databalancer:type=*, name=*"
+  # "kafka.log:type=*, name=*"
+  # "kafka.utils:type=*, name=*"
+  - pattern: kafka.(\w+)<type=(.+), name=(.+)><>(Count|Value)
+    name: kafka_$1_$2_$3
+  # "kafka.producer:type=*, client-id=*"
+  # "kafka.producer:type=*, id=*"
+  # "kafka.rest:type=*, client-id=*"
+  # "kafka.rest:type=*, http-status-code=*"
+  # "kafka.server:type=*, BrokerId=*"
+  # "kafka.server:type=*, listener=*"
+  # "kafka.server:type=*, id=*"
+  - pattern: kafka.(\w+)<type=(.+), (.+)=(.+)><>Value
+    name: kafka_$1_$2
+    labels:
+      "$3": "$4"
 
-- pattern : kafka.server<type=KafkaRequestHandlerPool, name=RequestHandlerAvgIdlePercent><>OneMinuteRate
-  name: kafka_server_kafkarequesthandlerpool_requesthandleravgidlepercent_total
-  type: GAUGE
-
-- pattern : kafka.server<type=socket-server-metrics, clientSoftwareName=(.+), clientSoftwareVersion=(.+), listener=(.+), networkProcessor=(.+)><>connections
-  name: kafka_server_socketservermetrics_connections
-  type: GAUGE
-  labels:
-    client_software_name: "$1"
-    client_software_version: "$2"
-    listener: "$3"
-    network_processor: "$4"
-
-- pattern : 'kafka.server<type=socket-server-metrics, listener=(.+), networkProcessor=(.+)><>(.+):'
-  name: kafka_server_socketservermetrics_$3
-  type: GAUGE
-  labels:
-    listener: "$1"
-    network_processor: "$2"
-
-# Count and Value
-- pattern: kafka.(.*)<type=(.+), name=(.+), (.+)=(.+), (.+)=(.+)><>(Count|Value)
-  name: kafka_$1_$2_$3
-  labels:
-    "$4": "$5"
-    "$6": "$7"
-- pattern: kafka.(.*)<type=(.+), name=(.+), (.+)=(.+)><>(Count|Value)
-  name: kafka_$1_$2_$3
-  labels:
-    "$4": "$5"
-- pattern: kafka.(.*)<type=(.+), name=(.+)><>(Count|Value)
-  name: kafka_$1_$2_$3
-
-# Percentile
-- pattern: kafka.(.*)<type=(.+), name=(.+), (.+)=(.*), (.+)=(.+)><>(\d+)thPercentile
-  name: kafka_$1_$2_$3
-  type: GAUGE
-  labels:
-    "$4": "$5"
-    "$6": "$7"
-    quantile: "0.$8"
-- pattern: kafka.(.*)<type=(.+), name=(.+), (.+)=(.*)><>(\d+)thPercentile
-  name: kafka_$1_$2_$3
-  type: GAUGE
-  labels:
-    "$4": "$5"
-    quantile: "0.$6"
-- pattern: kafka.(.*)<type=(.+), name=(.+)><>(\d+)thPercentile
-  name: kafka_$1_$2_$3
-  type: GAUGE
-  labels:
-    quantile: "0.$4"
+  - pattern: kafka.server<type=KafkaRequestHandlerPool, name=RequestHandlerAvgIdlePercent><>OneMinuteRate
+    name: kafka_server_kafkarequesthandlerpool_requesthandleravgidlepercent_total
+    type: GAUGE
+  # "kafka.server:type=*, listener=*, networkProcessor=*, clientSoftwareName=*, clientSoftwareVersion=*"
+  - pattern: kafka.server<type=socket-server-metrics, clientSoftwareName=(.+), clientSoftwareVersion=(.+), listener=(.+), networkProcessor=(.+)><>connections
+    name: kafka_server_socketservermetrics_connections
+    type: GAUGE
+    labels:
+      client_software_name: "$1"
+      client_software_version: "$2"
+      listener: "$3"
+      network_processor: "$4"
+  - pattern: "kafka.server<type=socket-server-metrics, listener=(.+), networkProcessor=(.+)><>(.+):"
+    name: kafka_server_socketservermetrics_$3
+    type: GAUGE
+    labels:
+      listener: "$1"
+      network_processor: "$2"
+  # "kafka.coordinator.group:type=*, name=*"
+  # "kafka.coordinator.transaction:type=*, name=*"
+  - pattern: kafka.coordinator.(\w+)<type=(.+), name=(.+)><>(Count|Value)
+    name: kafka_coordinator_$1_$2_$3
+  # Percentile
+  - pattern: kafka.(\w+)<type=(.+), name=(.+), (.+)=(.*)><>(\d+)thPercentile
+    name: kafka_$1_$2_$3
+    type: GAUGE
+    labels:
+      "$4": "$5"
+      quantile: "0.$6"
+  - pattern: kafka.(\w+)<type=(.+), name=(.+)><>(\d+)thPercentile
+    name: kafka_$1_$2_$3
+    type: GAUGE
+    labels:
+      quantile: "0.$4"
+  # Additional Rules for Confluent Server Metrics
+  # 'confluent.metadata:type=*, name=*, topic=*, partition=*'
+  - pattern: confluent.(\w+)<type=(.+), (.+)=(.+), (.+)=(.+), (.+)=(.+)><>Value
+    name: confluent_$1_$2
+    type: GAUGE
+    labels:
+      "$3": "$4"
+      "$5": "$6"
+      "$7": "$8"
+  # 'confluent.metadata.service:type=*, node-id=*, client-id=*'
+  - pattern: confluent.(.+)<type=(.+), (.+)=(.+), (.+)=(.+)><>Value
+    name: confluent_$1_$2
+    type: GAUGE
+    labels:
+      "$3": "$4"
+      "$5": "$6"
+  # 'confluent.metadata.service:type=*, client-id=*'
+  # 'confluent.metadata.service:type=*, id=*'
+  # 'confluent.metadata:type=*, name=*'
+  # 'confluent.license:type=*, name=*'
+  - pattern: confluent.(.+)<type=(.+), (.+)=(.+)><>Value
+    name: confluent_$1_$2
+    type: GAUGE
+    labels:
+      "$3": "$4"


### PR DESCRIPTION
The current JMX metrics rules for Kafka Broker were pretty stale and were not performing optimally. Removed all the greedy searches and moved them to a better word based search for ease of rule execution and about 100% lower parsing time. 