### PR TITLE
fix: devx-2690 remove volume mount trailing slashes

### DIFF
--- a/jmxexporter-prometheus-grafana/docker-compose.override.yml
+++ b/jmxexporter-prometheus-grafana/docker-compose.override.yml
@@ -54,7 +54,7 @@ services:
     ports:
       - 9090:9090
     volumes:
-      - $MONITORING_STACK/assets/prometheus/prometheus-config/:/etc/prometheus/
+      - $MONITORING_STACK/assets/prometheus/prometheus-config/:/etc/prometheus
 
   node-exporter:
     image: prom/node-exporter:v1.2.2
@@ -88,4 +88,4 @@ services:
     ports:
       - 3000:3000
     volumes:
-      - $MONITORING_STACK/assets/grafana/provisioning/:/etc/grafana/provisioning/
+      - $MONITORING_STACK/assets/grafana/provisioning/:/etc/grafana/provisioning


### PR DESCRIPTION
Also described in https://confluentinc.atlassian.net/browse/DEVX-2690

Trailling slashes in volume-mount configurations in docker-compose `yml` make the configs incompatible with Docker on Windows/WSL. 

Implemented FIX:
Remove trailing slashes from volume mount configs in `docker-compose.override.yml`

Reviewers:
Please double check that this doesn't break on Linux/MacOS
