### PR TITLE
Fixing incorrect units on quota dashboard

### DIFF
--- a/jmxexporter-prometheus-grafana/assets/grafana/provisioning/dashboards/kafka-quotas.json
+++ b/jmxexporter-prometheus-grafana/assets/grafana/provisioning/dashboards/kafka-quotas.json
@@ -9,7 +9,7 @@
         "iconColor": "rgba(0, 211, 255, 1)",
         "name": "Annotations & Alerts",
         "target": {
-          "limit": 100,
+          "limit": 100,a
           "matchAny": false,
           "tags": [],
           "type": "dashboard"
@@ -21,8 +21,8 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 10,
-  "iteration": 1633460006472,
+  "id": 1,
+  "iteration": 1644508335471,
   "links": [],
   "panels": [
     {
@@ -258,7 +258,7 @@
               }
             ]
           },
-          "unit": "percentunit"
+          "unit": "percent"
         },
         "overrides": []
       },
@@ -349,7 +349,7 @@
               }
             ]
           },
-          "unit": "Bps"
+          "unit": "ms"
         },
         "overrides": []
       },
@@ -440,7 +440,7 @@
               }
             ]
           },
-          "unit": "Bps"
+          "unit": "ms"
         },
         "overrides": []
       },
@@ -732,5 +732,5 @@
   "timezone": "",
   "title": "Kafka Quotas",
   "uid": "cwWEgYqMz",
-  "version": 1
+  "version": 3
 }

--- a/jmxexporter-prometheus-grafana/assets/grafana/provisioning/dashboards/kafka-quotas.json
+++ b/jmxexporter-prometheus-grafana/assets/grafana/provisioning/dashboards/kafka-quotas.json
@@ -9,7 +9,7 @@
         "iconColor": "rgba(0, 211, 255, 1)",
         "name": "Annotations & Alerts",
         "target": {
-          "limit": 100,a
+          "limit": 100,
           "matchAny": false,
           "tags": [],
           "type": "dashboard"
@@ -21,8 +21,8 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 1,
-  "iteration": 1644508335471,
+  "id": null,
+  "iteration": 1633460006472,
   "links": [],
   "panels": [
     {
@@ -732,5 +732,5 @@
   "timezone": "",
   "title": "Kafka Quotas",
   "uid": "cwWEgYqMz",
-  "version": 3
+  "version": 1
 }


### PR DESCRIPTION
The units on several graphs in the quotas Grafana dashboard were not appropriate.
This has been corrected.