### PR TITLE
feat(grafana): add topk to topics and quotas, and add error graph

### DIFF
--- a/jmxexporter-prometheus-grafana/README.md
+++ b/jmxexporter-prometheus-grafana/README.md
@@ -24,7 +24,7 @@ For Kafka to output quota metrics, at least one quota configuration is necessary
 
 A quota can be configured from the cp-demo folder using docker-compose:
 ```bash
-docker-compose exec kafka1 kafka-configs --bootstrap-server kafka1:12091 --alter --add-config 'producer_byte_rate=10000,consumer_byte_rate=30000,request_percentage=0.2' --entity-type users --entity-name appSA
+docker-compose exec kafka1 kafka-configs --bootstrap-server kafka1:12091 --alter --add-config 'producer_byte_rate=10000,consumer_byte_rate=30000,request_percentage=0.2' --entity-type users --entity-name unknown --entity-type clients --entity-name unknown
 ```
 
 ![Kafka quotas](img/kafka-quotas.png)

--- a/jmxexporter-prometheus-grafana/assets/grafana/provisioning/dashboards/kafka-cluster.json
+++ b/jmxexporter-prometheus-grafana/assets/grafana/provisioning/dashboards/kafka-cluster.json
@@ -23,7 +23,7 @@
   "gnetId": 721,
   "graphTooltip": 0,
   "id": 6,
-  "iteration": 1637943038134,
+  "iteration": 1647427255896,
   "links": [],
   "panels": [
     {
@@ -1013,6 +1013,91 @@
       "type": "stat"
     },
     {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 10
+      },
+      "id": 122,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max",
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "rate(kafka_network_requestmetrics_errorspersec{error!=\"NONE\"}[5m])",
+          "interval": "",
+          "legendFormat": "{{error}} @ {{hostname}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Errors",
+      "type": "timeseries"
+    },
+    {
       "cacheTimeout": null,
       "datasource": "Prometheus",
       "description": "Fetch request rate.",
@@ -1045,8 +1130,8 @@
       "gridPos": {
         "h": 4,
         "w": 4,
-        "x": 12,
-        "y": 10
+        "x": 0,
+        "y": 14
       },
       "id": 94,
       "interval": null,
@@ -1114,8 +1199,8 @@
       "gridPos": {
         "h": 4,
         "w": 4,
-        "x": 16,
-        "y": 10
+        "x": 4,
+        "y": 14
       },
       "id": 38,
       "interval": null,
@@ -1183,8 +1268,8 @@
       "gridPos": {
         "h": 4,
         "w": 4,
-        "x": 20,
-        "y": 10
+        "x": 8,
+        "y": 14
       },
       "id": 36,
       "interval": null,
@@ -1226,7 +1311,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 14
+        "y": 18
       },
       "id": 40,
       "panels": [],
@@ -1307,7 +1392,7 @@
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 15
+        "y": 19
       },
       "id": 27,
       "links": [],
@@ -1417,7 +1502,7 @@
         "h": 8,
         "w": 8,
         "x": 8,
-        "y": 15
+        "y": 19
       },
       "id": 2,
       "links": [],
@@ -1532,7 +1617,7 @@
         "h": 8,
         "w": 8,
         "x": 16,
-        "y": 15
+        "y": 19
       },
       "id": 3,
       "links": [],
@@ -1574,7 +1659,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 23
+        "y": 27
       },
       "id": 29,
       "panels": [
@@ -2152,7 +2237,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 24
+        "y": 28
       },
       "id": 44,
       "panels": [
@@ -2348,7 +2433,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 25
+        "y": 29
       },
       "id": 86,
       "panels": [
@@ -2822,7 +2907,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 26
+        "y": 30
       },
       "id": 82,
       "panels": [
@@ -3020,7 +3105,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 27
+        "y": 31
       },
       "id": 53,
       "panels": [
@@ -3211,7 +3296,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 28
+        "y": 32
       },
       "id": 58,
       "panels": [
@@ -3677,7 +3762,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 29
+        "y": 33
       },
       "id": 68,
       "panels": [
@@ -4145,7 +4230,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 30
+        "y": 34
       },
       "id": 66,
       "panels": [
@@ -4613,7 +4698,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 31
+        "y": 35
       },
       "id": 102,
       "panels": [
@@ -5342,7 +5427,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 32
+        "y": 36
       },
       "id": 120,
       "panels": [
@@ -5563,7 +5648,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 33
+        "y": 37
       },
       "id": 46,
       "panels": [
@@ -5894,7 +5979,7 @@
       {
         "allValue": "",
         "current": {
-          "selected": false,
+          "selected": true,
           "text": [
             "0.95"
           ],
@@ -5959,5 +6044,5 @@
   "timezone": "browser",
   "title": "Kafka cluster",
   "uid": "qu-QZdfZz",
-  "version": 1
+  "version": 2
 }

--- a/jmxexporter-prometheus-grafana/assets/grafana/provisioning/dashboards/kafka-quotas.json
+++ b/jmxexporter-prometheus-grafana/assets/grafana/provisioning/dashboards/kafka-quotas.json
@@ -21,8 +21,8 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": null,
-  "iteration": 1633460006472,
+  "id": 3,
+  "iteration": 1647426501739,
   "links": [],
   "panels": [
     {
@@ -105,9 +105,9 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "kafka_server_produce_byte_rate{user=~\"$user\",client_id=~\"$client_id\",instance=~\"$broker_id\",env=\"$env\",job=\"kafka-broker\"}",
+          "expr": "topk(10, kafka_server_produce_byte_rate{user=~\"$user\",client_id=~\"$client_id\",instance=~\"$broker_id\",env=\"$env\",job=\"kafka-broker\"})",
           "interval": "",
-          "legendFormat": "{{ user }} - {{ client_id }} (broker: {{ instance }})",
+          "legendFormat": "User: {{ user }} - Client: {{ client_id }} @ Broker: {{ instance }}",
           "refId": "A"
         }
       ],
@@ -196,9 +196,9 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "kafka_server_fetch_byte_rate{user=~\"$user\",client_id=~\"$client_id\",instance=~\"$broker_id\",env=\"$env\",job=\"kafka-broker\"}",
+          "expr": "topk(10, kafka_server_fetch_byte_rate{user=~\"$user\",client_id=~\"$client_id\",instance=~\"$broker_id\",env=\"$env\",job=\"kafka-broker\"})",
           "interval": "",
-          "legendFormat": "{{ user }} - {{ client_id }} (broker: {{ instance }})",
+          "legendFormat": "User: {{ user }} - Client: {{ client_id }} @ Broker: {{ instance }}",
           "refId": "A"
         }
       ],
@@ -287,9 +287,9 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "kafka_server_request_request_time{user=~\"$user\",client_id=~\"$client_id\",instance=~\"$broker_id\",env=\"$env\",job=\"kafka-broker\"}",
+          "expr": "topk(10, kafka_server_request_request_time{user=~\"$user\",client_id=~\"$client_id\",instance=~\"$broker_id\",env=\"$env\",job=\"kafka-broker\"})",
           "interval": "",
-          "legendFormat": "{{ user }} - {{ client_id }} (broker: {{ instance }})",
+          "legendFormat": "User: {{ user }} - Client: {{ client_id }} @ Broker: {{ instance }}",
           "refId": "A"
         }
       ],
@@ -378,9 +378,9 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "kafka_server_produce_throttle_time{user=~\"$user\",client_id=~\"$client_id\",instance=~\"$broker_id\",env=\"$env\",job=\"kafka-broker\"}",
+          "expr": "kafka_server_produce_throttle_time{user=~\"$user\",client_id=~\"$client_id\",instance=~\"$broker_id\",env=\"$env\",job=\"kafka-broker\"} > 0",
           "interval": "",
-          "legendFormat": "{{ user }} - {{ client_id }} (broker: {{ instance }})",
+          "legendFormat": "User: {{ user }} - Client: {{ client_id }} @ Broker: {{ instance }}",
           "refId": "A"
         }
       ],
@@ -469,9 +469,9 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "kafka_server_fetch_throttle_time{user=~\"$user\",client_id=~\"$client_id\",instance=~\"$broker_id\",env=\"$env\",job=\"kafka-broker\"}",
+          "expr": "kafka_server_fetch_throttle_time{user=~\"$user\",client_id=~\"$client_id\",instance=~\"$broker_id\",env=\"$env\",job=\"kafka-broker\"} > 0",
           "interval": "",
-          "legendFormat": "{{ user }} - {{ client_id }} (broker: {{ instance }})",
+          "legendFormat": "User: {{ user }} - Client: {{ client_id }} @ Broker: {{ instance }}",
           "refId": "A"
         }
       ],
@@ -560,9 +560,9 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "kafka_server_request_throttle_time{user=~\"$user\",client_id=~\"$client_id\",instance=~\"$broker_id\",env=\"$env\",job=\"kafka-broker\"}",
+          "expr": "kafka_server_request_throttle_time{user=~\"$user\",client_id=~\"$client_id\",instance=~\"$broker_id\",env=\"$env\",job=\"kafka-broker\"} > 0",
           "interval": "",
-          "legendFormat": "{{ user }} - {{ client_id }} (broker: {{ instance }})",
+          "legendFormat": "User: {{ user }} - Client: {{ client_id }} @ Broker: {{ instance }}",
           "refId": "A"
         }
       ],
@@ -732,5 +732,5 @@
   "timezone": "",
   "title": "Kafka Quotas",
   "uid": "cwWEgYqMz",
-  "version": 1
+  "version": 2
 }

--- a/jmxexporter-prometheus-grafana/assets/grafana/provisioning/dashboards/kafka-topics.json
+++ b/jmxexporter-prometheus-grafana/assets/grafana/provisioning/dashboards/kafka-topics.json
@@ -22,7 +22,7 @@
   "gnetId": null,
   "graphTooltip": 0,
   "id": 4,
-  "iteration": 1638467166173,
+  "iteration": 1647426704713,
   "links": [],
   "panels": [
     {
@@ -181,7 +181,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum without(instance) (rate(kafka_server_brokertopicmetrics_messagesinpersec{job=\"kafka-broker\",topic=~\"$topic\",env=~\"$env\"}[5m]))",
+          "expr": "topk(10, sum without(instance) (rate(kafka_server_brokertopicmetrics_messagesinpersec{job=\"kafka-broker\",topic=~\"$topic\",env=~\"$env\"}[5m])))",
           "interval": "",
           "legendFormat": "{{topic}}",
           "refId": "A"
@@ -270,7 +270,8 @@
       "pluginVersion": "8.1.3",
       "targets": [
         {
-          "expr": "sum(kafka_log_log_size{job=\"kafka-broker\",env=\"$env\",topic=~\"$topic\"}) by (topic)",
+          "exemplar": true,
+          "expr": "topk(10, sum(kafka_log_log_size{job=\"kafka-broker\",env=\"$env\",topic=~\"$topic\"}) by (topic))",
           "interval": "",
           "legendFormat": "{{topic}}",
           "refId": "A"
@@ -417,7 +418,8 @@
       "pluginVersion": "8.1.3",
       "targets": [
         {
-          "expr": "sum without(instance) (rate(kafka_server_brokertopicmetrics_bytesinpersec{job=\"kafka-broker\",topic=~\"$topic\",env=~\"$env\"}[5m]))",
+          "exemplar": true,
+          "expr": "topk(10, sum without(instance) (rate(kafka_server_brokertopicmetrics_bytesinpersec{job=\"kafka-broker\",topic=~\"$topic\",env=~\"$env\"}[5m])))",
           "interval": "",
           "legendFormat": "{{topic}}",
           "refId": "A"
@@ -505,7 +507,8 @@
       "pluginVersion": "8.1.3",
       "targets": [
         {
-          "expr": "sum without(instance) (rate(kafka_server_brokertopicmetrics_bytesoutpersec{job=\"kafka-broker\",topic=~\"$topic\",env=~\"$env\"}[5m]))",
+          "exemplar": true,
+          "expr": "topk(10, sum without(instance) (rate(kafka_server_brokertopicmetrics_bytesoutpersec{job=\"kafka-broker\",topic=~\"$topic\",env=~\"$env\"}[5m])))",
           "interval": "",
           "legendFormat": "{{topic}}",
           "refId": "A"
@@ -595,7 +598,8 @@
       "pluginVersion": "8.1.3",
       "targets": [
         {
-          "expr": "sum(rate(kafka_server_brokertopicmetrics_totalproducerequestspersec{job=\"kafka-broker\", env=\"$env\", topic=~\"$topic\"}[5m])) by (topic)",
+          "exemplar": true,
+          "expr": "topk(10, sum(rate(kafka_server_brokertopicmetrics_totalproducerequestspersec{job=\"kafka-broker\", env=\"$env\", topic=~\"$topic\"}[5m])) by (topic))",
           "interval": "",
           "legendFormat": "{{topic}}",
           "refId": "A"
@@ -685,7 +689,8 @@
       "pluginVersion": "8.1.3",
       "targets": [
         {
-          "expr": "sum(rate(kafka_server_brokertopicmetrics_totalfetchrequestspersec{job=\"kafka-broker\", env=\"$env\",topic=~\"$topic\"}[5m])) by (topic)",
+          "exemplar": true,
+          "expr": "topk(10, sum(rate(kafka_server_brokertopicmetrics_totalfetchrequestspersec{job=\"kafka-broker\", env=\"$env\",topic=~\"$topic\"}[5m])) by (topic))",
           "interval": "",
           "legendFormat": "{{topic}}",
           "refId": "A"
@@ -753,7 +758,31 @@
                 "properties": [
                   {
                     "id": "custom.width",
-                    "value": 226
+                    "value": 137
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "instance"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 155
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "topic"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 294
                   }
                 ]
               }
@@ -778,7 +807,8 @@
           "pluginVersion": "8.1.3",
           "targets": [
             {
-              "expr": "kafka_log_log_logstartoffset{job=\"kafka-broker\",env=~\"$env\",topic=~\"$topic\"}",
+              "exemplar": true,
+              "expr": "kafka_log_log_logstartoffset{job=\"kafka-broker\",env=~\"$env\",topic=\"$topic\"}",
               "format": "table",
               "instant": true,
               "interval": "",
@@ -864,7 +894,19 @@
                 "properties": [
                   {
                     "id": "custom.width",
-                    "value": 226
+                    "value": 105
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "topic"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 289
                   }
                 ]
               }
@@ -889,7 +931,8 @@
           "pluginVersion": "8.1.3",
           "targets": [
             {
-              "expr": "kafka_log_log_logendoffset{job=\"kafka-broker\",env=~\"$env\",topic=~\"$topic\"}",
+              "exemplar": true,
+              "expr": "kafka_log_log_logendoffset{job=\"kafka-broker\",env=~\"$env\",topic=\"$topic\"}",
               "format": "table",
               "instant": true,
               "interval": "",


### PR DESCRIPTION
Changes:

- Add topk function to reduce the cardinality of topics and quotas graphs. Client ID cardinality can kill the quotas dashboard.
- Tweak quotas example to expose metrics with users _and_ client id
- Add Errors graph to Kafka cluster dashboard:

![image](https://user-images.githubusercontent.com/6180701/158573374-a8f94b28-39da-4ac2-af22-1890b93159b9.png)
