### PR TITLE
Explicit mkdir prevents permissions block

### DIFF
--- a/ccloud-prometheus-grafana/start.sh
+++ b/ccloud-prometheus-grafana/start.sh
@@ -13,6 +13,7 @@ echo -e "Generate Prometheus Configuration from Environemnet variables for  $MON
 export OUTPUT_FILE=$MONITORING_STACK/assets/prometheus/prometheus-config/prometheus.yml
 echo " creating prometheus configuration file $OUTPUT_FILE "
 [[ -e $OUTPUT_FILE ]]; rm -f $OUTPUT_FILE 
+mkdir -p "$MONITORING_STACK/assets/prometheus/prometheus-config"
 source $MONITORING_STACK/utils/env_variables.env
 envsubst < $MONITORING_STACK/utils/prometheus-template.yml > $MONITORING_STACK/assets/prometheus/prometheus-config/prometheus.yml
 


### PR DESCRIPTION
This PR resolves #83 

Explicitly creating the directory `$MONITORING_STACK/assets/prometheus/prometheus-config/` using `mkdir -p` creates the directory with in the user context witht the right owner/mode.

Calling `mkdir -p` on an existing directory does nothing, so I believe it is safe for use in a newly cloned repo, as well as in a re-use scenario, where /prometheus/prometheus-config/ already exists. 


