### PR TITLE
fix: update lag exporter image

### DIFF
--- a/jmxexporter-prometheus-grafana/docker-compose.override.yaml
+++ b/jmxexporter-prometheus-grafana/docker-compose.override.yaml
@@ -70,7 +70,7 @@ services:
       - "^(aufs|proc|nsfs|shm|cgroup|tmpfs|binfmt_misc|debugfs|devpts|fusectl|hugetlbfs|fuse.lxcfs|mqueue|pstore|securityfs|sysfs|autofs|devtmpfs|configfs)"
 
   kafka-lag-exporter:
-    image: lightbend/kafka-lag-exporter:0.6.7
+    image: seglo/kafka-lag-exporter:0.7.0
     container_name: kafka-lag-exporter
     hostname: kafka-lag-exporter
     restart: always

--- a/jmxexporter-prometheus-grafana/docker-compose.override.yaml
+++ b/jmxexporter-prometheus-grafana/docker-compose.override.yaml
@@ -70,7 +70,7 @@ services:
       - "^(aufs|proc|nsfs|shm|cgroup|tmpfs|binfmt_misc|debugfs|devpts|fusectl|hugetlbfs|fuse.lxcfs|mqueue|pstore|securityfs|sysfs|autofs|devtmpfs|configfs)"
 
   kafka-lag-exporter:
-    image: seglo/kafka-lag-exporter:0.7.0
+    image: seglo/kafka-lag-exporter:0.7.1
     container_name: kafka-lag-exporter
     hostname: kafka-lag-exporter
     restart: always

--- a/metricbeat-elastic-kibana/docker-compose.override.yml
+++ b/metricbeat-elastic-kibana/docker-compose.override.yml
@@ -49,7 +49,7 @@ services:
       KAFKAREST_OPTS: -javaagent:/usr/share/jmx-exporter/jmx_prometheus_javaagent-0.16.1.jar=1234:/usr/share/jmx-exporter/confluent_rest.yml
 
   kafka-lag-exporter:
-    image: lightbend/kafka-lag-exporter:0.6.7
+    image: seglo/kafka-lag-exporter:0.7.1
     container_name: kafka-lag-exporter
     hostname: kafka-lag-exporter
     restart: always


### PR DESCRIPTION
Kafka Lag exporter is currently broken: 

```
Caused by: org.apache.kafka.common.KafkaException: org.apache.kafka.common.KafkaException: org.apache.kafka.common.KafkaException: Failed to load SSL keystore /etc/kafka/secrets/kafka.kafkaLagExporter.keystore.jks of type JKS
	at org.apache.kafka.common.network.SslChannelBuilder.configure(SslChannelBuilder.java:74)
	at org.apache.kafka.common.network.ChannelBuilders.create(ChannelBuilders.java:157)
	at org.apache.kafka.common.network.ChannelBuilders.clientChannelBuilder(ChannelBuilders.java:73)
	at org.apache.kafka.clients.ClientUtils.createChannelBuilder(ClientUtils.java:105)
	at org.apache.kafka.clients.consumer.KafkaConsumer.<init>(KafkaConsumer.java:743)
	... 24 common frames omitted
Caused by: org.apache.kafka.common.KafkaException: org.apache.kafka.common.KafkaException: Failed to load SSL keystore /etc/kafka/secrets/kafka.kafkaLagExporter.keystore.jks of type JKS
	at org.apache.kafka.common.security.ssl.SslEngineBuilder.createSSLContext(SslEngineBuilder.java:163)
	at org.apache.kafka.common.security.ssl.SslEngineBuilder.<init>(SslEngineBuilder.java:104)
	at org.apache.kafka.common.security.ssl.SslFactory.configure(SslFactory.java:95)
	at org.apache.kafka.common.network.SslChannelBuilder.configure(SslChannelBuilder.java:72)
	... 28 common frames omitted
Caused by: org.apache.kafka.common.KafkaException: Failed to load SSL keystore /etc/kafka/secrets/kafka.kafkaLagExporter.keystore.jks of type JKS
	at org.apache.kafka.common.security.ssl.SslEngineBuilder$SecurityStore.load(SslEngineBuilder.java:292)
	at org.apache.kafka.common.security.ssl.SslEngineBuilder.createSSLContext(SslEngineBuilder.java:144)
	... 31 common frames omitted
Caused by: java.io.IOException: Invalid keystore format
	at sun.security.provider.JavaKeyStore.engineLoad(JavaKeyStore.java:666)
	at sun.security.provider.JavaKeyStore$JKS.engineLoad(JavaKeyStore.java:57)
	at sun.security.provider.KeyStoreDelegator.engineLoad(KeyStoreDelegator.java:224)
	at sun.security.provider.JavaKeyStore$DualFormatJKS.engineLoad(JavaKeyStore.java:71)
	at java.security.KeyStore.load(KeyStore.java:1445)
	at org.apache.kafka.common.security.ssl.SslEngineBuilder$SecurityStore.load(SslEngineBuilder.java:289)
	... 32 common frames omitted
```

See more: https://github.com/seglo/kafka-lag-exporter/issues/270#issuecomment-1090992591

Updating image is fixing the issue.