### PR TITLE
Fix JMX Exporter rules

### DIFF
--- a/shared-assets/jmx-exporter/kafka_broker.yml
+++ b/shared-assets/jmx-exporter/kafka_broker.yml
@@ -28,16 +28,7 @@ blacklistObjectNames:
   - "confluent.metadata.service:type=app-info,client-id=*"
   - "confluent.metadata:type=kafkaauthstore,*"
 rules:
-  # This is by far the biggest contributor to the number of sheer metrics being produced.
-  # Always keep it on the top for the case of probability when so many metrics will hit the first condition and exit.
-  # "kafka.cluster:type=*, name=*, topic=*, partition=*"
-  # "kafka.log:type=*,name=*, topic=*, partition=*"
-  - pattern: kafka.(\w+)<type=(.+), name=(.+), topic=(.+), partition=(.+)><>Value
-    name: kafka_$1_$2_$3
-    type: GAUGE
-    labels:
-      topic: "$4"
-      partition: "$5"
+  # This rule is more specific than the next rule; it has to come before it otherwise it will never be hit
   # "kafka.server:type=*,name=*, client-id=*, topic=*, partition=*"
   - pattern: kafka.server<type=(.+), name=(.+), clientId=(.+), topic=(.+), partition=(.*)><>Value
     name: kafka_server_$1_$2
@@ -46,12 +37,44 @@ rules:
       clientId: "$3"
       topic: "$4"
       partition: "$5"
+  # This is by far the biggest contributor to the number of sheer metrics being produced.
+  # Always keep it near the top for the case of probability when so many metrics will hit the first condition and exit.
+  # "kafka.cluster:type=*, name=*, topic=*, partition=*"
+  # "kafka.log:type=*,name=*, topic=*, partition=*"
+  - pattern: kafka.(\w+)<type=(.+), name=(.+), topic=(.+), partition=(.+)><>Value
+    name: kafka_$1_$2_$3
+    type: GAUGE
+    labels:
+      topic: "$4"
+      partition: "$5"
+  # Next two rules are similar; Value version is a GAUGE; Count version is not
   - pattern: kafka.server<type=(.+), name=(.+), clientId=(.+), brokerHost=(.+), brokerPort=(.+)><>Value
     name: kafka_server_$1_$2
     type: GAUGE
     labels:
       clientId: "$3"
       broker: "$4:$5"
+  - pattern: kafka.server<type=(.+), name=(.+), clientId=(.+), brokerHost=(.+), brokerPort=(.+)><>Count
+    name: kafka_server_$1_$2
+    labels:
+      clientId: "$3"
+      broker: "$4:$5"
+  # Needed for Cluster Linking metrics
+  # "kafka.server:type=*, name=*, *=*, *=*, *=*, *=*"
+  - pattern: kafka.(\w+)<type=(.+), name=(.+), (.+)=(.+), (.+)=(.+), (.+)=(.+), (.+)=(.+)><>(Count|Value)
+    name: kafka_$1_$2_$3
+    labels:
+      "$4": "$5"
+      "$6": "$7"
+      "$8": "$9"
+      "$10": "$11"
+  # "kafka.server:type=*, name=*, *=*, *=*, *=*"
+  - pattern: kafka.(\w+)<type=(.+), name=(.+), (.+)=(.+), (.+)=(.+), (.+)=(.+)><>(Count|Value)
+    name: kafka_$1_$2_$3
+    labels:
+      "$4": "$5"
+      "$6": "$7"
+      "$8": "$9"
   # "kafka.network:type=*, name=*, request=*, error=*"
   # "kafka.network:type=*, name=*, request=*, version=*"
   - pattern: kafka.(\w+)<type=(.+), name=(.+), (.+)=(.+), (.+)=(.+)><>(Count|Value)

--- a/shared-assets/jmx-exporter/kafka_broker_p99only.yml
+++ b/shared-assets/jmx-exporter/kafka_broker_p99only.yml
@@ -19,16 +19,7 @@ blacklistObjectNames:
   - "kafka.server:type=*,cipher=*,protocol=*,listener=*,networkProcessor=*"
   - "kafka.server:type=*"
 rules:
-  # This is by far the biggest contributor to the number of sheer metrics being produced.
-  # Always keep it on the top for the case of probability when so many metrics will hit the first condition and exit.
-  # "kafka.cluster:type=*, name=*, topic=*, partition=*"
-  # "kafka.log:type=*,name=*, topic=*, partition=*"
-  - pattern: kafka.(\w+)<type=(.+), name=(.+), topic=(.+), partition=(.+)><>Value
-    name: kafka_$1_$2_$3
-    type: GAUGE
-    labels:
-      topic: "$4"
-      partition: "$5"
+  # This rule is more specific than the next rule; it has to come before it otherwise it will never be hit
   # "kafka.server:type=*,name=*, client-id=*, topic=*, partition=*"
   - pattern: kafka.server<type=(.+), name=(.+), clientId=(.+), topic=(.+), partition=(.*)><>Value
     name: kafka_server_$1_$2
@@ -37,12 +28,44 @@ rules:
       clientId: "$3"
       topic: "$4"
       partition: "$5"
+  # This is by far the biggest contributor to the number of sheer metrics being produced.
+  # Always keep it near the top for the case of probability when so many metrics will hit the first condition and exit.
+  # "kafka.cluster:type=*, name=*, topic=*, partition=*"
+  # "kafka.log:type=*,name=*, topic=*, partition=*"
+  - pattern: kafka.(\w+)<type=(.+), name=(.+), topic=(.+), partition=(.+)><>Value
+    name: kafka_$1_$2_$3
+    type: GAUGE
+    labels:
+      topic: "$4"
+      partition: "$5"
+  # Next two rules are similar; Value version is a GAUGE; Count version is not
   - pattern: kafka.server<type=(.+), name=(.+), clientId=(.+), brokerHost=(.+), brokerPort=(.+)><>Value
     name: kafka_server_$1_$2
     type: GAUGE
     labels:
       clientId: "$3"
       broker: "$4:$5"
+  - pattern: kafka.server<type=(.+), name=(.+), clientId=(.+), brokerHost=(.+), brokerPort=(.+)><>Count
+    name: kafka_server_$1_$2
+    labels:
+      clientId: "$3"
+      broker: "$4:$5"
+  # Needed for Cluster Linking metrics
+  # "kafka.server:type=*, name=*, *=*, *=*, *=*, *=*"
+  - pattern: kafka.(\w+)<type=(.+), name=(.+), (.+)=(.+), (.+)=(.+), (.+)=(.+), (.+)=(.+)><>(Count|Value)
+    name: kafka_$1_$2_$3
+    labels:
+      "$4": "$5"
+      "$6": "$7"
+      "$8": "$9"
+      "$10": "$11"
+  # "kafka.server:type=*, name=*, *=*, *=*, *=*"
+  - pattern: kafka.(\w+)<type=(.+), name=(.+), (.+)=(.+), (.+)=(.+), (.+)=(.+)><>(Count|Value)
+    name: kafka_$1_$2_$3
+    labels:
+      "$4": "$5"
+      "$6": "$7"
+      "$8": "$9"
   # "kafka.network:type=*, name=*, request=*, error=*"
   # "kafka.network:type=*, name=*, request=*, version=*"
   - pattern: kafka.(\w+)<type=(.+), name=(.+), (.+)=(.+), (.+)=(.+)><>(Count|Value)


### PR DESCRIPTION
See also: https://github.com/confluentinc/cp-ansible/pull/1304

Has four changes:
* Move the more-specific rule containing 'type,name,clientId,topic,partition' ABOVE less-specific rule containing 'type,name,topic,partition' so that clientId is properly parsed as a separate capture group (rather than as part of the name). This initially resulted in the 'name' capture group looking something like this: 'ConsumerLag, clientId=ReplicaFetcherThread-0-103-Default'
* Creates a duplicate of the rule capturing 'type, name, clientId, brokerHost, brokerPort', but with a Count instead of Value
* Create two additional rules capturing arbitrary key-value pairs when there are 6 and 5 arbitrary pairs (in front of the rule capturing 4 arbitrary pairs


Sample problematic JMX / Prometheus metrics:

Original:
```
kafka_server_fetcherlagmetrics_consumerlag_clientid_replicafetcherthread_0_103_default{partition="5",topic="test2",} 0.0
```

Fixed:
```
# HELP kafka_server_fetcherlagmetrics_consumerlag Attribute exposed for management (kafka.server<type=FetcherLagMetrics, name=ConsumerLag, clientId=ReplicaFetcherThread-0-103-Default, topic=test2, partition=5><>Value)
# TYPE kafka_server_fetcherlagmetrics_consumerlag gauge
kafka_server_fetcherlagmetrics_consumerlag{clientid="ReplicaFetcherThread-0-103-Default",partition="5",topic="test2",} 0.0
```

Original:
```
kafka_server_fetcherstats_requestspersec_clientid_replicafetcherthread_0_103_default{brokerhost="ip-10-18-1-101.ec2.internal",brokerport="9091",} 10251.0
```

Fixed:
```
# HELP kafka_server_fetcherstats_requestspersec Attribute exposed for management (kafka.server<type=FetcherStats, name=RequestsPerSec, clientId=ReplicaFetcherThread-0-103-Default, brokerHost=ip-10-18-1-101.ec2.internal, brokerPort=9091><>Count)
# TYPE kafka_server_fetcherstats_requestspersec untyped
kafka_server_fetcherstats_requestspersec{broker="ip-10-18-1-101.ec2.internal:9091",clientid="ReplicaFetcherThread-0-103-Default",} 17845.0
```

Original:
```
kafka_server_fetcherlagmetrics_consumerlag_clientid_clusterlinkfetcherthread_0_100_102_default{partition="0, link-name=100",topic="test",} 0.0
```

Fixed:
```
# HELP kafka_server_fetcherlagmetrics_consumerlag Attribute exposed for management (kafka.server<type=FetcherLagMetrics, name=ConsumerLag, clientId=ClusterLinkFetcherThread-0-100-102-Default, topic=test, partition=0, link-name=100><>Value)
# TYPE kafka_server_fetcherlagmetrics_consumerlag gauge
kafka_server_fetcherlagmetrics_consumerlag{clientid="ClusterLinkFetcherThread-0-100-102-Default",partition="0, link-name=100",topic="test",} 0.0
```

Original:
```
kafka_server_fetcherstats_bytespersec_clientid_clusterlinkfetcherthread_0_100_102_default_brokerhost_ip_10_18_1_100_ec2_internal{brokerport="9092",link_name="100",} 2214983.0
```

Fixed:
```
# HELP kafka_server_fetcherstats_bytespersec Attribute exposed for management (kafka.server<type=FetcherStats, name=BytesPerSec, clientId=ClusterLinkFetcherThread-0-100-102-Default, brokerHost=ip-10-18-1-100.ec2.internal, brokerPort=9092, link-name=100><>Count)
# TYPE kafka_server_fetcherstats_bytespersec untyped
kafka_server_fetcherstats_bytespersec{broker="ip-10-18-1-100.ec2.internal:9092, link-name=100",clientid="ClusterLinkFetcherThread-0-100-102-Default",} 3279024.0
```