### PR TITLE
fixed expression in Topic offsets  row

### DIFF
--- a/jmxexporter-prometheus-grafana/assets/grafana/provisioning/dashboards/kafka-topics.json
+++ b/jmxexporter-prometheus-grafana/assets/grafana/provisioning/dashboards/kafka-topics.json
@@ -808,7 +808,7 @@
           "targets": [
             {
               "exemplar": true,
-              "expr": "kafka_log_log_logstartoffset{job=\"kafka-broker\",env=~\"$env\",topic=\"$topic\"}",
+              "expr": "kafka_log_log_logstartoffset{job=\"kafka-broker\",env=~\"$env\",topic=~\"$topic\"}",
               "format": "table",
               "instant": true,
               "interval": "",
@@ -932,7 +932,7 @@
           "targets": [
             {
               "exemplar": true,
-              "expr": "kafka_log_log_logendoffset{job=\"kafka-broker\",env=~\"$env\",topic=\"$topic\"}",
+              "expr": "kafka_log_log_logendoffset{job=\"kafka-broker\",env=~\"$env\",topic=~\"$topic\"}",
               "format": "table",
               "instant": true,
               "interval": "",


### PR DESCRIPTION
 problem related to `kafka_log_log_logendoffset` and `kafka_log_log_logstartoffset` panels where panels don't work as the query returns no data because expression try to match topic name to the list of topics


fixed it by using `=~` regex matches operator instead of  `=`exactly equal operator 