### PR TITLE
Fix/grafana dashboards

### DIFF
--- a/jmxexporter-prometheus-grafana/assets/grafana/provisioning/dashboards/kafka-cluster.json
+++ b/jmxexporter-prometheus-grafana/assets/grafana/provisioning/dashboards/kafka-cluster.json
@@ -2699,7 +2699,7 @@
           "pluginVersion": "8.1.3",
           "targets": [
             {
-              "expr": "kafka_server_sessionexpirelistener_zookeepersyncconnectspersec{job=\"kafka-broker\",env=\"$env\",instance=~\"$instance\"}",
+              "expr": "rate(kafka_server_sessionexpirelistener_zookeepersyncconnectspersec{job=\"kafka-broker\",env=\"$env\",instance=~\"$instance\"}[5m])",
               "hide": false,
               "instant": false,
               "interval": "",
@@ -2792,7 +2792,7 @@
           "pluginVersion": "8.1.3",
           "targets": [
             {
-              "expr": "kafka_server_sessionexpirelistener_zookeeperexpirespersec{job=\"kafka-broker\",env=\"$env\",instance=~\"$instance\"}",
+              "expr": "rate(kafka_server_sessionexpirelistener_zookeeperexpirespersec{job=\"kafka-broker\",env=\"$env\",instance=~\"$instance\"}[5m])",
               "hide": false,
               "interval": "",
               "legendFormat": "{{instance}}",
@@ -2884,7 +2884,7 @@
           "pluginVersion": "8.1.3",
           "targets": [
             {
-              "expr": "kafka_server_sessionexpirelistener_zookeeperdisconnectspersec{job=\"kafka-broker\",env=\"$env\",instance=~\"$instance\"}",
+              "expr": "rate(kafka_server_sessionexpirelistener_zookeeperdisconnectspersec{job=\"kafka-broker\",env=\"$env\",instance=~\"$instance\"}[5m])",
               "hide": false,
               "interval": "",
               "legendFormat": "{{instance}}",
@@ -2976,7 +2976,7 @@
           "pluginVersion": "8.1.3",
           "targets": [
             {
-              "expr": "kafka_server_sessionexpirelistener_zookeeperauthfailurespersec{job=\"kafka-broker\",env=\"$env\",instance=~\"$instance\"}",
+              "expr": "rate(kafka_server_sessionexpirelistener_zookeeperauthfailurespersec{job=\"kafka-broker\",env=\"$env\",instance=~\"$instance\"}[5m])",
               "hide": false,
               "interval": "",
               "legendFormat": "{{instance}}",

--- a/jmxexporter-prometheus-grafana/assets/grafana/provisioning/dashboards/kafka-lag-exporter.json
+++ b/jmxexporter-prometheus-grafana/assets/grafana/provisioning/dashboards/kafka-lag-exporter.json
@@ -101,7 +101,7 @@
 		"steppedLine": false,
 		"targets": [
 		  {
-			"expr": "topk(50, kafka_consumergroup_group_max_lag_seconds{namespace=\"$namespace\",cluster_name=\"$cluster_name\",group=~\"$consumer_group\"})",
+			"expr": "topk(50, kafka_consumergroup_group_max_lag_seconds{cluster_name=\"$cluster_name\",group=~\"$consumer_group\"})",
 			"format": "time_series",
 			"hide": false,
 			"intervalFactor": 1,
@@ -187,7 +187,7 @@
 		"steppedLine": false,
 		"targets": [
 		  {
-			"expr": "topk(25, kafka_consumergroup_group_lag_seconds{namespace=\"$namespace\",cluster_name=\"$cluster_name\",group=~\"$consumer_group\"})",
+			"expr": "topk(25, kafka_consumergroup_group_lag_seconds{cluster_name=\"$cluster_name\",group=~\"$consumer_group\"})",
 			"format": "time_series",
 			"hide": false,
 			"intervalFactor": 1,
@@ -275,7 +275,7 @@
 		"steppedLine": false,
 		"targets": [
 		  {
-			"expr": "topk(50, kafka_consumergroup_group_max_lag{namespace=\"$namespace\",cluster_name=\"$cluster_name\",group=~\"$consumer_group\"})",
+			"expr": "topk(50, kafka_consumergroup_group_max_lag{cluster_name=\"$cluster_name\",group=~\"$consumer_group\"})",
 			"format": "time_series",
 			"hide": false,
 			"intervalFactor": 1,
@@ -361,7 +361,7 @@
 		"steppedLine": false,
 		"targets": [
 		  {
-			"expr": "topk(25, kafka_consumergroup_group_lag{namespace=\"$namespace\",cluster_name=\"$cluster_name\",group=~\"$consumer_group\"})",
+			"expr": "topk(25, kafka_consumergroup_group_lag{cluster_name=\"$cluster_name\",group=~\"$consumer_group\"})",
 			"format": "time_series",
 			"hide": false,
 			"intervalFactor": 1,
@@ -476,7 +476,7 @@
 		"steppedLine": false,
 		"targets": [
 		  {
-			"expr": "kafka_consumergroup_group_max_lag_seconds{namespace=\"$namespace\",cluster_name=\"$cluster_name\",group=~\"$consumer_group\"}",
+			"expr": "kafka_consumergroup_group_max_lag_seconds{cluster_name=\"$cluster_name\",group=~\"$consumer_group\"}",
 			"format": "time_series",
 			"hide": false,
 			"intervalFactor": 1,
@@ -484,7 +484,7 @@
 			"refId": "A"
 		  },
 		  {
-			"expr": "kafka_consumergroup_group_max_lag{namespace=\"$namespace\",cluster_name=\"$cluster_name\",group=~\"$consumer_group\"}",
+			"expr": "kafka_consumergroup_group_max_lag{cluster_name=\"$cluster_name\",group=~\"$consumer_group\"}",
 			"format": "time_series",
 			"hide": false,
 			"intervalFactor": 1,
@@ -601,7 +601,7 @@
 		"steppedLine": false,
 		"targets": [
 		  {
-			"expr": "max(kafka_consumergroup_group_lag_seconds{namespace=\"$namespace\",cluster_name=\"$cluster_name\",group=~\"$consumer_group\"}) by (group)",
+			"expr": "max(kafka_consumergroup_group_lag_seconds{cluster_name=\"$cluster_name\",group=~\"$consumer_group\"}) by (group)",
 			"format": "time_series",
 			"hide": false,
 			"intervalFactor": 1,
@@ -609,7 +609,7 @@
 			"refId": "A"
 		  },
 		  {
-			"expr": "sum(kafka_consumergroup_group_offset{namespace=\"$namespace\",cluster_name=\"$cluster_name\",group=~\"$consumer_group\"})",
+			"expr": "sum(kafka_consumergroup_group_offset{cluster_name=\"$cluster_name\",group=~\"$consumer_group\"})",
 			"format": "time_series",
 			"hide": false,
 			"intervalFactor": 1,
@@ -617,7 +617,7 @@
 			"refId": "B"
 		  },
 		  {
-			"expr": "sum((kafka_consumergroup_group_offset{namespace=\"$namespace\",cluster_name=\"$cluster_name\",group=~\"$consumer_group\"} * 0)\n+ on(namespace,cluster_name,topic,partition) group_left() kafka_partition_latest_offset{namespace=\"$namespace\",cluster_name=\"$cluster_name\"})",
+			"expr": "sum((kafka_consumergroup_group_offset{cluster_name=\"$cluster_name\",group=~\"$consumer_group\"} * 0)\n+ on(cluster_name,topic,partition) group_left() kafka_partition_latest_offset{cluster_name=\"$cluster_name\"})",
 			"format": "time_series",
 			"intervalFactor": 1,
 			"legendFormat": "Sum of latest offsets",
@@ -943,32 +943,11 @@
 		  "datasource": "Prometheus",
 		  "hide": 0,
 		  "includeAll": false,
-		  "label": "Namespace",
-		  "multi": false,
-		  "name": "namespace",
-		  "options": [],
-		  "query": "query_result(kafka_consumergroup_group_lag)",
-		  "refresh": 1,
-		  "regex": "/.*namespace=\"([^\"]*).*/",
-		  "skipUrlSync": false,
-		  "sort": 1,
-		  "tagValuesQuery": "",
-		  "tags": [],
-		  "tagsQuery": "",
-		  "type": "query",
-		  "useTags": false
-		},
-		{
-		  "allValue": null,
-		  "current": {},
-		  "datasource": "Prometheus",
-		  "hide": 0,
-		  "includeAll": false,
 		  "label": "Cluster Name",
 		  "multi": false,
 		  "name": "cluster_name",
 		  "options": [],
-		  "query": "query_result(kafka_consumergroup_group_lag{namespace=\"$namespace\"})",
+		  "query": "query_result(kafka_consumergroup_group_lag)",
 		  "refresh": 1,
 		  "regex": "/.*cluster_name=\"([^\"]*).*/",
 		  "skipUrlSync": false,
@@ -989,7 +968,7 @@
 		  "multi": true,
 		  "name": "consumer_group",
 		  "options": [],
-		  "query": "query_result(kafka_consumergroup_group_lag{namespace=\"$namespace\",cluster_name=\"$cluster_name\"})",
+		  "query": "query_result(kafka_consumergroup_group_lag{cluster_name=\"$cluster_name\"})",
 		  "refresh": 1,
 		  "regex": "/.*group=\"([^\"]*).*/",
 		  "skipUrlSync": false,


### PR DESCRIPTION
This branch aims to fix two Grafana Dashboard definition :

- The Kafka Broker one that contains persec zookeeper metrics that must be rated (rate(**metricX**[5m]) to be usable on a daily basis
- The Lag Exporter one that refer to a non-existent namespace variable in the lag exporter standard metrics 