### PR TITLE
Summarize ingress and egress at the top in Confluent Cloud dashboard

### DIFF
--- a/ccloud-prometheus-grafana/assets/grafana/provisioning/dashboards/ccloud.json
+++ b/ccloud-prometheus-grafana/assets/grafana/provisioning/dashboards/ccloud.json
@@ -22,11 +22,9 @@
     ]
   },
   "editable": true,
-  "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
   "id": 2,
   "links": [],
-  "liveNow": false,
   "panels": [
     {
       "collapsed": false,

--- a/ccloud-prometheus-grafana/assets/grafana/provisioning/dashboards/ccloud.json
+++ b/ccloud-prometheus-grafana/assets/grafana/provisioning/dashboards/ccloud.json
@@ -3,7 +3,10 @@
     "list": [
       {
         "builtIn": 1,
-        "datasource": "-- Grafana --",
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
         "enable": true,
         "hide": true,
         "iconColor": "rgba(0, 211, 255, 1)",
@@ -19,15 +22,18 @@
     ]
   },
   "editable": true,
-  "gnetId": null,
+  "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 1,
-  "iteration": 1687425228917,
+  "id": 2,
   "links": [],
+  "liveNow": false,
   "panels": [
     {
       "collapsed": false,
-      "datasource": "Prometheus",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -36,11 +42,23 @@
       },
       "id": 21,
       "panels": [],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "refId": "A"
+        }
+      ],
       "title": "Global",
       "type": "row"
     },
     {
-      "datasource": null,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
       "description": "The number of registered schemas",
       "fieldConfig": {
         "defaults": {
@@ -75,7 +93,9 @@
       "options": {
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["max"],
+          "calcs": [
+            "max"
+          ],
           "fields": "",
           "values": false
         },
@@ -83,7 +103,7 @@
         "showThresholdMarkers": true,
         "text": {}
       },
-      "pluginVersion": "8.1.3",
+      "pluginVersion": "10.1.2",
       "targets": [
         {
           "datasource": {
@@ -105,7 +125,10 @@
       "type": "gauge"
     },
     {
-      "datasource": null,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
       "description": "The number of registered schemas",
       "fieldConfig": {
         "defaults": {
@@ -140,7 +163,9 @@
       "options": {
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["max"],
+          "calcs": [
+            "max"
+          ],
           "fields": "",
           "values": false
         },
@@ -148,7 +173,7 @@
         "showThresholdMarkers": true,
         "text": {}
       },
-      "pluginVersion": "8.1.3",
+      "pluginVersion": "10.1.2",
       "targets": [
         {
           "datasource": {
@@ -170,7 +195,10 @@
       "type": "gauge"
     },
     {
-      "datasource": null,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
       "description": "The number of registered schemas",
       "fieldConfig": {
         "defaults": {
@@ -205,7 +233,9 @@
       "options": {
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["max"],
+          "calcs": [
+            "max"
+          ],
           "fields": "",
           "values": false
         },
@@ -213,7 +243,7 @@
         "showThresholdMarkers": true,
         "text": {}
       },
-      "pluginVersion": "8.1.3",
+      "pluginVersion": "10.1.2",
       "targets": [
         {
           "datasource": {
@@ -235,7 +265,10 @@
       "type": "gauge"
     },
     {
-      "datasource": null,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
       "description": "The number of registered schemas",
       "fieldConfig": {
         "defaults": {
@@ -270,7 +303,9 @@
       "options": {
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -278,7 +313,7 @@
         "showThresholdMarkers": true,
         "text": {}
       },
-      "pluginVersion": "8.1.3",
+      "pluginVersion": "10.1.2",
       "targets": [
         {
           "datasource": {
@@ -298,7 +333,10 @@
       "type": "gauge"
     },
     {
-      "datasource": "Prometheus",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
       "description": "Basic clusters have a max retained bytes limit of 5 TB prior to replication. ccloud_metrics_retained_bytes is after replication thus needs to be divided by 3.",
       "fieldConfig": {
         "defaults": {
@@ -342,62 +380,41 @@
         "justifyMode": "auto",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "8.1.3",
+      "pluginVersion": "10.1.2",
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
           "expr": "sum(confluent_kafka_server_retained_bytes{topic=~\"$topic\", kafka_id=~\"$cluster\"})/3",
           "interval": "",
           "legendFormat": "{{cluster}}",
           "refId": "A"
         }
       ],
-      "timeFrom": null,
-      "timeShift": null,
       "title": "Retained bytes ",
       "type": "stat"
     },
     {
-      "datasource": "Prometheus",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
       "description": "Per-second average rate of ingress of data to topics, basic cluster has a max of 100MBps.",
       "fieldConfig": {
         "defaults": {
           "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
+            "mode": "thresholds"
           },
           "mappings": [],
           "max": 100000000,
@@ -431,32 +448,43 @@
       },
       "id": 17,
       "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom"
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
         },
-        "tooltip": {
-          "mode": "single"
-        }
+        "textMode": "auto"
       },
-      "pluginVersion": "8.1.3",
+      "pluginVersion": "10.1.2",
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
           "exemplar": true,
-          "expr": "rate(confluent_kafka_server_received_bytes{topic=~\"$topic\", kafka_id=~\"$cluster\"}[1m])",
+          "expr": "sum(rate(confluent_kafka_server_received_bytes{topic=~\"$topic\", kafka_id=~\"$cluster\"}[1m]))",
           "interval": "",
           "legendFormat": "{{kafka_id}}",
+          "range": true,
           "refId": "A"
         }
       ],
-      "timeFrom": null,
-      "timeShift": null,
       "title": "Write on topics (rate)",
-      "type": "timeseries"
+      "type": "stat"
     },
     {
-      "datasource": "Prometheus",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
       "description": "Per-second average rate of egress data to topics, basic cluster has a max of 100MBps.",
       "fieldConfig": {
         "defaults": {
@@ -500,29 +528,43 @@
         "justifyMode": "auto",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["mean"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
-        "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "8.1.3",
+      "pluginVersion": "10.1.2",
       "targets": [
         {
-          "expr": "rate(confluent_kafka_server_sent_bytes{topic=~\"$topic\", kafka_id=~\"$cluster\"}[$__rate_interval])",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum(rate(confluent_kafka_server_sent_bytes{topic=~\"$topic\", kafka_id=~\"$cluster\"}[1m]))",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
           "interval": "",
-          "legendFormat": "{{cluster}}",
-          "refId": "A"
+          "legendFormat": "{{topic}}",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
         }
       ],
-      "timeFrom": null,
-      "timeShift": null,
       "title": "Read of topics (rate)",
       "type": "stat"
     },
     {
-      "datasource": "Prometheus",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
       "description": "Per-second average rate of requests, basic cluster maxes out at 1500 requests per second.",
       "fieldConfig": {
         "defaults": {
@@ -566,29 +608,38 @@
         "justifyMode": "auto",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "8.1.3",
+      "pluginVersion": "10.1.2",
       "targets": [
         {
-          "expr": "sum(rate(confluent_kafka_server_request_count{type=~\".*\", kafka_id=~\"$cluster\"}[$__rate_interval]))",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(confluent_kafka_server_request_count{type=~\".*\", kafka_id=~\"$cluster\"}[1m]))",
           "interval": "",
           "legendFormat": "{{cluster}}",
+          "range": true,
           "refId": "A"
         }
       ],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Requests (rate)",
+      "title": "Request Count (rate)",
       "type": "stat"
     },
     {
-      "datasource": "Prometheus",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
       "description": "The average active connections to a cluster. Basic clusters limit active connections to 1000.",
       "fieldConfig": {
         "defaults": {
@@ -633,16 +684,22 @@
         "justifyMode": "auto",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["max"],
+          "calcs": [
+            "max"
+          ],
           "fields": "",
           "values": false
         },
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "8.1.3",
+      "pluginVersion": "10.1.2",
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
           "expr": "avg(confluent_kafka_server_active_connection_count{kafka_id=~\"$cluster\"})",
           "hide": false,
           "interval": "",
@@ -650,13 +707,14 @@
           "refId": "A"
         }
       ],
-      "timeFrom": null,
-      "timeShift": null,
       "title": "Avg. Active connections",
       "type": "stat"
     },
     {
-      "datasource": "Prometheus",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
       "description": "The sum of partitions in a cluster. Basic cluster max partitions limit is 2048.",
       "fieldConfig": {
         "defaults": {
@@ -664,6 +722,8 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
@@ -675,6 +735,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -726,15 +787,21 @@
         "legend": {
           "calcs": [],
           "displayMode": "list",
-          "placement": "bottom"
+          "placement": "bottom",
+          "showLegend": true
         },
         "tooltip": {
-          "mode": "single"
+          "mode": "single",
+          "sort": "none"
         }
       },
       "pluginVersion": "8.1.3",
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
           "exemplar": true,
           "expr": "confluent_kafka_server_partition_count{kafka_id=~\"$cluster\"}",
           "hide": false,
@@ -743,13 +810,14 @@
           "refId": "A"
         }
       ],
-      "timeFrom": null,
-      "timeShift": null,
       "title": "Partition count ",
       "type": "timeseries"
     },
     {
-      "datasource": "Prometheus",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
       "description": "Basic clusters have a limit on the number of partitions that can be created and deleted in a 5 minute period. This single stat provides the absolute difference between the number of partitions are the beginning and end of the 5 minute period. This over simplifies the problem, so more conservative thresholds are put in place. ",
       "fieldConfig": {
         "defaults": {
@@ -757,6 +825,8 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
@@ -768,6 +838,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -819,15 +890,21 @@
         "legend": {
           "calcs": [],
           "displayMode": "list",
-          "placement": "bottom"
+          "placement": "bottom",
+          "showLegend": true
         },
         "tooltip": {
-          "mode": "single"
+          "mode": "single",
+          "sort": "none"
         }
       },
       "pluginVersion": "8.1.3",
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
           "exemplar": true,
           "expr": "abs(delta(confluent_kafka_server_partition_count{kafka_id=~\"$cluster\"}[5m]))",
           "format": "time_series",
@@ -839,13 +916,14 @@
           "refId": "A"
         }
       ],
-      "timeFrom": null,
-      "timeShift": null,
       "title": "Partition count change (delta)",
       "type": "timeseries"
     },
     {
-      "datasource": null,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
       "description": "The lag between a group member's committed offset and the partition's high watermark.",
       "fieldConfig": {
         "defaults": {
@@ -853,6 +931,8 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
@@ -864,6 +944,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -908,10 +989,12 @@
         "legend": {
           "calcs": [],
           "displayMode": "list",
-          "placement": "bottom"
+          "placement": "bottom",
+          "showLegend": true
         },
         "tooltip": {
-          "mode": "single"
+          "mode": "single",
+          "sort": "none"
         }
       },
       "pluginVersion": "8.3.3",
@@ -933,7 +1016,10 @@
       "type": "timeseries"
     },
     {
-      "datasource": null,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
       "description": "The average active connections to a cluster. Basic clusters limit active connections to 1000.",
       "fieldConfig": {
         "defaults": {
@@ -941,6 +1027,8 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
@@ -952,6 +1040,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -996,10 +1085,12 @@
         "legend": {
           "calcs": [],
           "displayMode": "list",
-          "placement": "bottom"
+          "placement": "bottom",
+          "showLegend": true
         },
         "tooltip": {
-          "mode": "single"
+          "mode": "single",
+          "sort": "none"
         }
       },
       "pluginVersion": "8.3.3",
@@ -1022,7 +1113,10 @@
     },
     {
       "collapsed": false,
-      "datasource": "Prometheus",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -1031,6 +1125,15 @@
       },
       "id": 16,
       "panels": [],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "refId": "A"
+        }
+      ],
       "title": "Topics",
       "type": "row"
     },
@@ -1039,7 +1142,10 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
       "description": "The current count of bytes retained by the cluster, summed across all partitions. The count is sampled every 60 seconds.",
       "fieldConfig": {
         "defaults": {
@@ -1077,7 +1183,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.1.3",
+      "pluginVersion": "10.1.2",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1087,6 +1193,10 @@
       "steppedLine": false,
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
           "expr": "sum by (kafka_id, topic) (confluent_kafka_server_retained_bytes{topic=~\"$topic\", kafka_id=~\"$cluster\"})",
           "hide": false,
           "interval": "",
@@ -1095,9 +1205,7 @@
         }
       ],
       "thresholds": [],
-      "timeFrom": null,
       "timeRegions": [],
-      "timeShift": null,
       "title": "Topic retained bytes",
       "tooltip": {
         "shared": true,
@@ -1106,36 +1214,26 @@
       },
       "type": "graph",
       "xaxis": {
-        "buckets": null,
         "mode": "time",
-        "name": null,
         "show": true,
         "values": []
       },
       "yaxes": [
         {
           "$$hashKey": "object:53",
-          "decimals": null,
           "format": "decbytes",
-          "label": null,
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         },
         {
           "$$hashKey": "object:54",
           "format": "short",
-          "label": null,
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         }
       ],
       "yaxis": {
-        "align": false,
-        "alignLevel": null
+        "align": false
       }
     },
     {
@@ -1143,7 +1241,10 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
       "description": "The delta count of bytes received from the network. Each sample is the number of bytes received since the previous data sample. The count is sampled every 60 seconds.",
       "fieldConfig": {
         "defaults": {
@@ -1177,7 +1278,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.1.3",
+      "pluginVersion": "10.1.2",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1187,6 +1288,10 @@
       "steppedLine": false,
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
           "expr": "sum by (topic, kafka_id) (confluent_kafka_server_received_bytes{topic=~\"$topic\", kafka_id=~\"$cluster\"})",
           "hide": false,
           "interval": "",
@@ -1195,9 +1300,7 @@
         }
       ],
       "thresholds": [],
-      "timeFrom": null,
       "timeRegions": [],
-      "timeShift": null,
       "title": "Topic received bytes",
       "tooltip": {
         "shared": true,
@@ -1206,34 +1309,26 @@
       },
       "type": "graph",
       "xaxis": {
-        "buckets": null,
         "mode": "time",
-        "name": null,
         "show": true,
         "values": []
       },
       "yaxes": [
         {
-          "decimals": null,
+          "$$hashKey": "object:335",
           "format": "decbytes",
-          "label": null,
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         },
         {
+          "$$hashKey": "object:336",
           "format": "short",
-          "label": null,
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         }
       ],
       "yaxis": {
-        "align": false,
-        "alignLevel": null
+        "align": false
       }
     },
     {
@@ -1241,7 +1336,10 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
       "description": "The delta count of bytes sent over the network. Each sample is the number of bytes sent since the previous data point. The count is sampled every 60 seconds.",
       "fieldConfig": {
         "defaults": {
@@ -1277,7 +1375,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.1.3",
+      "pluginVersion": "10.1.2",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1287,6 +1385,10 @@
       "steppedLine": false,
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
           "expr": "sum by (topic, kafka_id) (confluent_kafka_server_sent_bytes{topic=~\"$topic\", kafka_id=~\"$cluster\"})",
           "hide": false,
           "interval": "",
@@ -1295,9 +1397,7 @@
         }
       ],
       "thresholds": [],
-      "timeFrom": null,
       "timeRegions": [],
-      "timeShift": null,
       "title": "Topic Sent bytes",
       "tooltip": {
         "shared": true,
@@ -1306,33 +1406,26 @@
       },
       "type": "graph",
       "xaxis": {
-        "buckets": null,
         "mode": "time",
-        "name": null,
         "show": true,
         "values": []
       },
       "yaxes": [
         {
+          "$$hashKey": "object:371",
           "format": "decbytes",
-          "label": null,
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         },
         {
+          "$$hashKey": "object:372",
           "format": "short",
-          "label": null,
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         }
       ],
       "yaxis": {
-        "align": false,
-        "alignLevel": null
+        "align": false
       }
     },
     {
@@ -1340,7 +1433,10 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
       "description": "The delta count of records received. Each sample is the number of records received since the previous data sample. The count is sampled every 60 seconds.",
       "fieldConfig": {
         "defaults": {
@@ -1374,7 +1470,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.1.3",
+      "pluginVersion": "10.1.2",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1384,6 +1480,10 @@
       "steppedLine": false,
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
           "expr": "sum by (topic, kafka_id) (confluent_kafka_server_received_records{topic=~\"$topic\", kafka_id=~\"$cluster\"})",
           "hide": false,
           "interval": "",
@@ -1392,9 +1492,7 @@
         }
       ],
       "thresholds": [],
-      "timeFrom": null,
       "timeRegions": [],
-      "timeShift": null,
       "title": "Topic received record",
       "tooltip": {
         "shared": true,
@@ -1403,34 +1501,24 @@
       },
       "type": "graph",
       "xaxis": {
-        "buckets": null,
         "mode": "time",
-        "name": null,
         "show": true,
         "values": []
       },
       "yaxes": [
         {
-          "decimals": null,
           "format": "none",
-          "label": null,
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         },
         {
           "format": "none",
-          "label": null,
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         }
       ],
       "yaxis": {
-        "align": false,
-        "alignLevel": null
+        "align": false
       }
     },
     {
@@ -1438,7 +1526,10 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
       "description": "The delta count of records sent. Each sample is the number of records sent since the previous data point. The count is sampled every 60 seconds.",
       "fieldConfig": {
         "defaults": {
@@ -1472,7 +1563,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.1.3",
+      "pluginVersion": "10.1.2",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1482,6 +1573,10 @@
       "steppedLine": false,
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
           "expr": "sum by (topic, kafka_id) (confluent_kafka_server_sent_records{topic=~\"$topic\", kafka_id=~\"$cluster\"})",
           "hide": false,
           "interval": "",
@@ -1490,9 +1585,7 @@
         }
       ],
       "thresholds": [],
-      "timeFrom": null,
       "timeRegions": [],
-      "timeShift": null,
       "title": "Topic sent records",
       "tooltip": {
         "shared": true,
@@ -1501,34 +1594,24 @@
       },
       "type": "graph",
       "xaxis": {
-        "buckets": null,
         "mode": "time",
-        "name": null,
         "show": true,
         "values": []
       },
       "yaxes": [
         {
-          "decimals": null,
           "format": "none",
-          "label": null,
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         },
         {
           "format": "none",
-          "label": null,
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         }
       ],
       "yaxis": {
-        "align": false,
-        "alignLevel": null
+        "align": false
       }
     },
     {
@@ -1536,7 +1619,10 @@
       "bars": true,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
       "description": "The delta count of requests received over the network. Each sample is the number of requests received since the previous data point. The count sampled every 60 seconds.",
       "fieldConfig": {
         "defaults": {
@@ -1574,7 +1660,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.1.3",
+      "pluginVersion": "10.1.2",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1584,6 +1670,10 @@
       "steppedLine": false,
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
           "expr": "confluent_kafka_server_request_count{kafka_id=~\"$cluster\"}",
           "hide": false,
           "interval": "",
@@ -1592,9 +1682,7 @@
         }
       ],
       "thresholds": [],
-      "timeFrom": null,
       "timeRegions": [],
-      "timeShift": null,
       "title": "Request rate",
       "tooltip": {
         "shared": true,
@@ -1603,39 +1691,32 @@
       },
       "type": "graph",
       "xaxis": {
-        "buckets": null,
         "mode": "time",
-        "name": null,
         "show": true,
         "values": []
       },
       "yaxes": [
         {
-          "decimals": null,
           "format": "short",
-          "label": null,
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         },
         {
           "format": "short",
-          "label": null,
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         }
       ],
       "yaxis": {
-        "align": false,
-        "alignLevel": null
+        "align": false
       }
     },
     {
       "collapsed": false,
-      "datasource": "Prometheus",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -1644,6 +1725,15 @@
       },
       "id": 33,
       "panels": [],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "refId": "A"
+        }
+      ],
       "title": "Connectors",
       "type": "row"
     },
@@ -1652,7 +1742,10 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -1679,7 +1772,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.1.3",
+      "pluginVersion": "10.1.2",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1689,6 +1782,10 @@
       "steppedLine": false,
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
           "expr": "confluent_kafka_connect_sent_records{connector_id=~\"$cluster\"}",
           "interval": "",
           "legendFormat": "{{connector_id}} -- {{connector_id}}",
@@ -1697,9 +1794,7 @@
         }
       ],
       "thresholds": [],
-      "timeFrom": null,
       "timeRegions": [],
-      "timeShift": null,
       "title": "Sent records",
       "tooltip": {
         "shared": true,
@@ -1708,33 +1803,24 @@
       },
       "type": "graph",
       "xaxis": {
-        "buckets": null,
         "mode": "time",
-        "name": null,
         "show": true,
         "values": []
       },
       "yaxes": [
         {
           "format": "short",
-          "label": null,
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         },
         {
           "format": "short",
-          "label": null,
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         }
       ],
       "yaxis": {
-        "align": false,
-        "alignLevel": null
+        "align": false
       }
     },
     {
@@ -1742,7 +1828,10 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -1769,7 +1858,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.1.3",
+      "pluginVersion": "10.1.2",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1779,6 +1868,10 @@
       "steppedLine": false,
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
           "expr": "confluent_kafka_connect_received_bytes{connector_id=~\"$cluster\"}",
           "interval": "",
           "legendFormat": "{{connector_id}} -- {{connector_id}}",
@@ -1787,9 +1880,7 @@
         }
       ],
       "thresholds": [],
-      "timeFrom": null,
       "timeRegions": [],
-      "timeShift": null,
       "title": "Received bytes",
       "tooltip": {
         "shared": true,
@@ -1798,33 +1889,24 @@
       },
       "type": "graph",
       "xaxis": {
-        "buckets": null,
         "mode": "time",
-        "name": null,
         "show": true,
         "values": []
       },
       "yaxes": [
         {
           "format": "short",
-          "label": null,
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         },
         {
           "format": "short",
-          "label": null,
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         }
       ],
       "yaxis": {
-        "align": false,
-        "alignLevel": null
+        "align": false
       }
     },
     {
@@ -1832,7 +1914,10 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -1859,7 +1944,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "8.1.3",
+      "pluginVersion": "10.1.2",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1869,6 +1954,10 @@
       "steppedLine": false,
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
           "exemplar": true,
           "expr": "confluent_kafka_connect_dead_letter_queue_records{connector_id=~\"$cluster\"}",
           "interval": "",
@@ -1878,9 +1967,7 @@
         }
       ],
       "thresholds": [],
-      "timeFrom": null,
       "timeRegions": [],
-      "timeShift": null,
       "title": "Dead Letter Queue bytes",
       "tooltip": {
         "shared": true,
@@ -1889,9 +1976,7 @@
       },
       "type": "graph",
       "xaxis": {
-        "buckets": null,
         "mode": "time",
-        "name": null,
         "show": true,
         "values": []
       },
@@ -1899,25 +1984,19 @@
         {
           "$$hashKey": "object:308",
           "format": "short",
-          "label": null,
           "logBase": 1,
-          "max": null,
           "min": "0",
           "show": true
         },
         {
           "$$hashKey": "object:309",
           "format": "short",
-          "label": null,
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         }
       ],
       "yaxis": {
-        "align": false,
-        "alignLevel": null
+        "align": false
       }
     },
     {
@@ -1925,7 +2004,10 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -1962,6 +2044,10 @@
       "steppedLine": false,
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
           "expr": "confluent_kafka_connect_sent_bytes{connector_id=~\"$cluster\"}",
           "interval": "",
           "legendFormat": "{{connector_id}} -- {{connector_id}}",
@@ -1970,9 +2056,7 @@
         }
       ],
       "thresholds": [],
-      "timeFrom": null,
       "timeRegions": [],
-      "timeShift": null,
       "title": "Sent bytes",
       "tooltip": {
         "shared": true,
@@ -1981,33 +2065,24 @@
       },
       "type": "graph",
       "xaxis": {
-        "buckets": null,
         "mode": "time",
-        "name": null,
         "show": true,
         "values": []
       },
       "yaxes": [
         {
           "format": "short",
-          "label": null,
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         },
         {
           "format": "short",
-          "label": null,
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         }
       ],
       "yaxis": {
-        "align": false,
-        "alignLevel": null
+        "align": false
       }
     },
     {
@@ -2015,7 +2090,10 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -2052,6 +2130,10 @@
       "steppedLine": false,
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
           "expr": "confluent_kafka_connect_received_records{connector_id=~\"$cluster\"}",
           "interval": "",
           "legendFormat": "{{connector_id}} -- {{connector_id}}",
@@ -2060,9 +2142,7 @@
         }
       ],
       "thresholds": [],
-      "timeFrom": null,
       "timeRegions": [],
-      "timeShift": null,
       "title": "Received records",
       "tooltip": {
         "shared": true,
@@ -2071,38 +2151,32 @@
       },
       "type": "graph",
       "xaxis": {
-        "buckets": null,
         "mode": "time",
-        "name": null,
         "show": true,
         "values": []
       },
       "yaxes": [
         {
           "format": "short",
-          "label": null,
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         },
         {
           "format": "short",
-          "label": null,
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         }
       ],
       "yaxis": {
-        "align": false,
-        "alignLevel": null
+        "align": false
       }
     },
     {
       "collapsed": false,
-      "datasource": "Prometheus",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -2111,11 +2185,23 @@
       },
       "id": 42,
       "panels": [],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "refId": "A"
+        }
+      ],
       "title": "ksqlDB",
       "type": "row"
     },
     {
-      "datasource": "Prometheus",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -2124,8 +2210,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -2161,6 +2246,10 @@
       "pluginVersion": "8.1.3",
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
           "exemplar": true,
           "expr": "confluent_kafka_ksql_streaming_unit_count",
           "interval": "",
@@ -2169,13 +2258,14 @@
           "refId": "A"
         }
       ],
-      "timeFrom": null,
-      "timeShift": null,
       "title": "ksqlDB streaming unit",
       "type": "stat"
     },
     {
-      "datasource": "Prometheus",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -2184,8 +2274,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -2221,6 +2310,10 @@
       "pluginVersion": "8.1.3",
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
           "expr": "count(confluent_kafka_ksql_streaming_unit_count)",
           "interval": "",
           "legendFormat": "",
@@ -2228,14 +2321,15 @@
           "refId": "A"
         }
       ],
-      "timeFrom": null,
-      "timeShift": null,
       "title": "ksqlDB application count",
       "type": "stat"
     },
     {
       "collapsed": false,
-      "datasource": "Prometheus",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -2244,6 +2338,15 @@
       },
       "id": 25,
       "panels": [],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "refId": "A"
+        }
+      ],
       "title": "Metrics API",
       "type": "row"
     },
@@ -2287,7 +2390,10 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
       "fieldConfig": {
         "defaults": {
           "links": []
@@ -2330,6 +2436,10 @@
       "steppedLine": false,
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
           "expr": "scrape_duration_seconds{job=\"Confluent Cloud\"}",
           "interval": "",
           "legendFormat": "{{instance}}",
@@ -2346,9 +2456,7 @@
           "visible": true
         }
       ],
-      "timeFrom": null,
       "timeRegions": [],
-      "timeShift": null,
       "title": "Scrape duration",
       "tooltip": {
         "shared": true,
@@ -2357,38 +2465,29 @@
       },
       "type": "graph",
       "xaxis": {
-        "buckets": null,
         "mode": "time",
-        "name": null,
         "show": true,
         "values": []
       },
       "yaxes": [
         {
           "format": "short",
-          "label": null,
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         },
         {
           "format": "s",
-          "label": null,
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         }
       ],
       "yaxis": {
-        "align": false,
-        "alignLevel": null
+        "align": false
       }
     }
   ],
-  "refresh": "5s",
-  "schemaVersion": 30,
+  "refresh": "1m",
+  "schemaVersion": 38,
   "style": "dark",
   "tags": [],
   "templating": {
@@ -2404,10 +2503,11 @@
             "$__all"
           ]
         },
-        "datasource": "Prometheus",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "PBFA97CFB590B2093"
+        },
         "definition": "label_values(confluent_kafka_server_retained_bytes, kafka_id)",
-        "description": null,
-        "error": null,
         "hide": 0,
         "includeAll": true,
         "label": "Cluster",
@@ -2438,10 +2538,11 @@
             "$__all"
           ]
         },
-        "datasource": "Prometheus",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "PBFA97CFB590B2093"
+        },
         "definition": "label_values(confluent_kafka_server_retained_bytes, topic)",
-        "description": null,
-        "error": null,
         "hide": 0,
         "includeAll": true,
         "label": "Topics",
@@ -2464,7 +2565,7 @@
     ]
   },
   "time": {
-    "from": "now-1h",
+    "from": "now-30m",
     "to": "now"
   },
   "timepicker": {
@@ -2484,5 +2585,6 @@
   "timezone": "",
   "title": "Confluent Cloud",
   "uid": "fhX5408Zk",
-  "version": 6
+  "version": 9,
+  "weekStart": ""
 }

--- a/ccloud-prometheus-grafana/assets/grafana/provisioning/dashboards/ccloud.json
+++ b/ccloud-prometheus-grafana/assets/grafana/provisioning/dashboards/ccloud.json
@@ -3,7 +3,10 @@
     "list": [
       {
         "builtIn": 1,
-        "datasource": "Prometheus",
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
         "enable": true,
         "hide": true,
         "iconColor": "rgba(0, 211, 255, 1)",
@@ -38,7 +41,7 @@
       "panels": [],
       "targets": [
         {
-          : "Prometheus",
+          "datasource": "Prometheus",
           "refId": "A"
         }
       ],
@@ -46,7 +49,7 @@
       "type": "row"
     },
     {
-      : "Prometheus",
+      "datasource": "Prometheus",
       "description": "The number of registered schemas",
       "fieldConfig": {
         "defaults": {
@@ -94,7 +97,7 @@
       "pluginVersion": "8.1.3",
       "targets": [
         {
-          : "Prometheus",
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "count (confluent_kafka_server_partition_count)",
           "format": "time_series",
@@ -110,7 +113,7 @@
       "type": "gauge"
     },
     {
-      : "Prometheus",
+      "datasource": "Prometheus",
       "description": "The number of registered schemas",
       "fieldConfig": {
         "defaults": {
@@ -158,7 +161,7 @@
       "pluginVersion": "8.1.3",
       "targets": [
         {
-          : "Prometheus",
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "count(confluent_kafka_connect_sent_bytes)",
           "format": "time_series",
@@ -174,7 +177,7 @@
       "type": "gauge"
     },
     {
-      : "Prometheus",
+      "datasource": "Prometheus",
       "description": "The number of registered schemas",
       "fieldConfig": {
         "defaults": {
@@ -222,7 +225,7 @@
       "pluginVersion": "8.1.3",
       "targets": [
         {
-          : "Prometheus",
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "count(confluent_kafka_ksql_streaming_unit_count)",
           "format": "time_series",
@@ -238,7 +241,7 @@
       "type": "gauge"
     },
     {
-      : "Prometheus",
+      "datasource": "Prometheus",
       "description": "The number of registered schemas",
       "fieldConfig": {
         "defaults": {
@@ -286,7 +289,7 @@
       "pluginVersion": "8.1.3",
       "targets": [
         {
-          : "Prometheus",
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "confluent_kafka_schema_registry_schema_count",
           "format": "time_series",
@@ -300,7 +303,7 @@
       "type": "gauge"
     },
     {
-      : "Prometheus",
+      "datasource": "Prometheus",
       "description": "Basic clusters have a max retained bytes limit of 5 TB prior to replication. ccloud_metrics_retained_bytes is after replication thus needs to be divided by 3.",
       "fieldConfig": {
         "defaults": {
@@ -356,7 +359,7 @@
       "pluginVersion": "8.1.3",
       "targets": [
         {
-          : "Prometheus",
+          "datasource": "Prometheus",
           "expr": "sum(confluent_kafka_server_retained_bytes{topic=~\"$topic\", kafka_id=~\"$cluster\"})/3",
           "interval": "",
           "legendFormat": "{{cluster}}",
@@ -367,7 +370,7 @@
       "type": "stat"
     },
     {
-      : "Prometheus",
+      "datasource": "Prometheus",
       "description": "Per-second average rate of ingress of data to topics, basic cluster has a max of 100MBps.",
       "fieldConfig": {
         "defaults": {
@@ -422,7 +425,7 @@
       "pluginVersion": "8.1.3",
       "targets": [
         {
-          : "Prometheus",
+          "datasource": "Prometheus",
           "editorMode": "code",
           "exemplar": true,
           "expr": "sum(rate(confluent_kafka_server_received_bytes{topic=~\"$topic\", kafka_id=~\"$cluster\"}[1m]))",
@@ -436,7 +439,7 @@
       "type": "stat"
     },
     {
-      : "Prometheus",
+      "datasource": "Prometheus",
       "description": "Per-second average rate of egress data to topics, basic cluster has a max of 100MBps.",
       "fieldConfig": {
         "defaults": {
@@ -491,7 +494,7 @@
       "pluginVersion": "8.1.3",
       "targets": [
         {
-          : "Prometheus",
+          "datasource": "Prometheus",
           "disableTextWrap": false,
           "editorMode": "code",
           "exemplar": false,
@@ -510,7 +513,7 @@
       "type": "stat"
     },
     {
-      : "Prometheus",
+      "datasource": "Prometheus",
       "description": "Per-second average rate of requests, basic cluster maxes out at 1500 requests per second.",
       "fieldConfig": {
         "defaults": {
@@ -566,7 +569,7 @@
       "pluginVersion": "8.1.3",
       "targets": [
         {
-          : "Prometheus",
+          "datasource": "Prometheus",
           "editorMode": "code",
           "expr": "sum(rate(confluent_kafka_server_request_count{type=~\".*\", kafka_id=~\"$cluster\"}[1m]))",
           "interval": "",
@@ -579,7 +582,7 @@
       "type": "stat"
     },
     {
-      : "Prometheus",
+      "datasource": "Prometheus",
       "description": "The average active connections to a cluster. Basic clusters limit active connections to 1000.",
       "fieldConfig": {
         "defaults": {
@@ -636,7 +639,7 @@
       "pluginVersion": "8.1.3",
       "targets": [
         {
-          : "Prometheus",
+          "datasource": "Prometheus",
           "expr": "avg(confluent_kafka_server_active_connection_count{kafka_id=~\"$cluster\"})",
           "hide": false,
           "interval": "",
@@ -648,7 +651,7 @@
       "type": "stat"
     },
     {
-      : "Prometheus",
+      "datasource": "Prometheus",
       "description": "The sum of partitions in a cluster. Basic cluster max partitions limit is 2048.",
       "fieldConfig": {
         "defaults": {
@@ -732,7 +735,7 @@
       "pluginVersion": "8.1.3",
       "targets": [
         {
-          : "Prometheus",
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "confluent_kafka_server_partition_count{kafka_id=~\"$cluster\"}",
           "hide": false,
@@ -745,7 +748,7 @@
       "type": "timeseries"
     },
     {
-      : "Prometheus",
+      "datasource": "Prometheus",
       "description": "Basic clusters have a limit on the number of partitions that can be created and deleted in a 5 minute period. This single stat provides the absolute difference between the number of partitions are the beginning and end of the 5 minute period. This over simplifies the problem, so more conservative thresholds are put in place. ",
       "fieldConfig": {
         "defaults": {
@@ -829,7 +832,7 @@
       "pluginVersion": "8.1.3",
       "targets": [
         {
-          : "Prometheus",
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "abs(delta(confluent_kafka_server_partition_count{kafka_id=~\"$cluster\"}[5m]))",
           "format": "time_series",
@@ -845,7 +848,7 @@
       "type": "timeseries"
     },
     {
-      : "Prometheus",
+      "datasource": "Prometheus",
       "description": "The lag between a group member's committed offset and the partition's high watermark.",
       "fieldConfig": {
         "defaults": {
@@ -922,7 +925,7 @@
       "pluginVersion": "8.3.3",
       "targets": [
         {
-          : "Prometheus",
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "sum by (consumer_group_id, topic) (confluent_kafka_server_consumer_lag_offsets{topic=~\"$topic\", kafka_id=~\"$cluster\"})",
           "hide": false,
@@ -935,7 +938,7 @@
       "type": "timeseries"
     },
     {
-      : "Prometheus",
+      "datasource": "Prometheus",
       "description": "The average active connections to a cluster. Basic clusters limit active connections to 1000.",
       "fieldConfig": {
         "defaults": {
@@ -1012,7 +1015,7 @@
       "pluginVersion": "8.3.3",
       "targets": [
         {
-          : "Prometheus",
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "confluent_kafka_server_successful_authentication_count{}",
           "hide": false,
@@ -1026,7 +1029,7 @@
     },
     {
       "collapsed": false,
-      : "Prometheus",
+      "datasource": "Prometheus",
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -1037,7 +1040,7 @@
       "panels": [],
       "targets": [
         {
-          : "Prometheus",
+          "datasource": "Prometheus",
           "refId": "A"
         }
       ],
@@ -1049,7 +1052,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      : "Prometheus",
+      "datasource": "Prometheus",
       "description": "The current count of bytes retained by the cluster, summed across all partitions. The count is sampled every 60 seconds.",
       "fieldConfig": {
         "defaults": {
@@ -1097,7 +1100,7 @@
       "steppedLine": false,
       "targets": [
         {
-          : "Prometheus",
+          "datasource": "Prometheus",
           "expr": "sum by (kafka_id, topic) (confluent_kafka_server_retained_bytes{topic=~\"$topic\", kafka_id=~\"$cluster\"})",
           "hide": false,
           "interval": "",
@@ -1142,7 +1145,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      : "Prometheus",
+      "datasource": "Prometheus",
       "description": "The delta count of bytes received from the network. Each sample is the number of bytes received since the previous data sample. The count is sampled every 60 seconds.",
       "fieldConfig": {
         "defaults": {
@@ -1186,7 +1189,7 @@
       "steppedLine": false,
       "targets": [
         {
-          : "Prometheus",
+          "datasource": "Prometheus",
           "expr": "sum by (topic, kafka_id) (confluent_kafka_server_received_bytes{topic=~\"$topic\", kafka_id=~\"$cluster\"})",
           "hide": false,
           "interval": "",
@@ -1231,7 +1234,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      : "Prometheus",
+      "datasource": "Prometheus",
       "description": "The delta count of bytes sent over the network. Each sample is the number of bytes sent since the previous data point. The count is sampled every 60 seconds.",
       "fieldConfig": {
         "defaults": {
@@ -1277,7 +1280,7 @@
       "steppedLine": false,
       "targets": [
         {
-          : "Prometheus",
+          "datasource": "Prometheus",
           "expr": "sum by (topic, kafka_id) (confluent_kafka_server_sent_bytes{topic=~\"$topic\", kafka_id=~\"$cluster\"})",
           "hide": false,
           "interval": "",
@@ -1322,7 +1325,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      : "Prometheus",
+      "datasource": "Prometheus",
       "description": "The delta count of records received. Each sample is the number of records received since the previous data sample. The count is sampled every 60 seconds.",
       "fieldConfig": {
         "defaults": {
@@ -1366,7 +1369,7 @@
       "steppedLine": false,
       "targets": [
         {
-          : "Prometheus",
+          "datasource": "Prometheus",
           "expr": "sum by (topic, kafka_id) (confluent_kafka_server_received_records{topic=~\"$topic\", kafka_id=~\"$cluster\"})",
           "hide": false,
           "interval": "",
@@ -1409,7 +1412,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      : "Prometheus",
+      "datasource": "Prometheus",
       "description": "The delta count of records sent. Each sample is the number of records sent since the previous data point. The count is sampled every 60 seconds.",
       "fieldConfig": {
         "defaults": {
@@ -1453,7 +1456,7 @@
       "steppedLine": false,
       "targets": [
         {
-          : "Prometheus",
+          "datasource": "Prometheus",
           "expr": "sum by (topic, kafka_id) (confluent_kafka_server_sent_records{topic=~\"$topic\", kafka_id=~\"$cluster\"})",
           "hide": false,
           "interval": "",
@@ -1496,7 +1499,7 @@
       "bars": true,
       "dashLength": 10,
       "dashes": false,
-      : "Prometheus",
+      "datasource": "Prometheus",
       "description": "The delta count of requests received over the network. Each sample is the number of requests received since the previous data point. The count sampled every 60 seconds.",
       "fieldConfig": {
         "defaults": {

--- a/ccloud-prometheus-grafana/assets/grafana/provisioning/dashboards/ccloud.json
+++ b/ccloud-prometheus-grafana/assets/grafana/provisioning/dashboards/ccloud.json
@@ -94,7 +94,7 @@
         "showThresholdMarkers": true,
         "text": {}
       },
-      "pluginVersion": "10.1.2",
+      "pluginVersion": "8.1.3",
       "targets": [
         {
           "datasource": "Prometheus",
@@ -158,7 +158,7 @@
         "showThresholdMarkers": true,
         "text": {}
       },
-      "pluginVersion": "10.1.2",
+      "pluginVersion": "8.1.3",
       "targets": [
         {
           "datasource": "Prometheus",
@@ -222,7 +222,7 @@
         "showThresholdMarkers": true,
         "text": {}
       },
-      "pluginVersion": "10.1.2",
+      "pluginVersion": "8.1.3",
       "targets": [
         {
           "datasource": "Prometheus",
@@ -286,7 +286,7 @@
         "showThresholdMarkers": true,
         "text": {}
       },
-      "pluginVersion": "10.1.2",
+      "pluginVersion": "8.1.3",
       "targets": [
         {
           "datasource": "Prometheus",
@@ -356,7 +356,7 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "10.1.2",
+      "pluginVersion": "8.1.3",
       "targets": [
         {
           "datasource": "Prometheus",
@@ -422,7 +422,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "10.1.2",
+      "pluginVersion": "8.1.3",
       "targets": [
         {
           "datasource": "Prometheus",
@@ -491,7 +491,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "10.1.2",
+      "pluginVersion": "8.1.3",
       "targets": [
         {
           "datasource": "Prometheus",
@@ -566,7 +566,7 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "10.1.2",
+      "pluginVersion": "8.1.3",
       "targets": [
         {
           "datasource": "Prometheus",
@@ -636,7 +636,7 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "10.1.2",
+      "pluginVersion": "8.1.3",
       "targets": [
         {
           "datasource": "Prometheus",
@@ -1090,7 +1090,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "10.1.2",
+      "pluginVersion": "8.1.3",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1179,7 +1179,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "10.1.2",
+      "pluginVersion": "8.1.3",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1270,7 +1270,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "10.1.2",
+      "pluginVersion": "8.1.3",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1359,7 +1359,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "10.1.2",
+      "pluginVersion": "8.1.3",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1446,7 +1446,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "10.1.2",
+      "pluginVersion": "8.1.3",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1537,7 +1537,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "10.1.2",
+      "pluginVersion": "8.1.3",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1637,7 +1637,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "10.1.2",
+      "pluginVersion": "8.1.3",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1717,7 +1717,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "10.1.2",
+      "pluginVersion": "8.1.3",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1797,7 +1797,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "10.1.2",
+      "pluginVersion": "8.1.3",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",

--- a/ccloud-prometheus-grafana/assets/grafana/provisioning/dashboards/ccloud.json
+++ b/ccloud-prometheus-grafana/assets/grafana/provisioning/dashboards/ccloud.json
@@ -3,10 +3,7 @@
     "list": [
       {
         "builtIn": 1,
-        "datasource": {
-          "type": "datasource",
-          "uid": "grafana"
-        },
+        "datasource": "Prometheus",
         "enable": true,
         "hide": true,
         "iconColor": "rgba(0, 211, 255, 1)",
@@ -41,7 +38,7 @@
       "panels": [],
       "targets": [
         {
-          "datasource": "Prometheus",
+          : "Prometheus",
           "refId": "A"
         }
       ],
@@ -49,7 +46,7 @@
       "type": "row"
     },
     {
-      "datasource": "Prometheus",
+      : "Prometheus",
       "description": "The number of registered schemas",
       "fieldConfig": {
         "defaults": {
@@ -97,7 +94,7 @@
       "pluginVersion": "8.1.3",
       "targets": [
         {
-          "datasource": "Prometheus",
+          : "Prometheus",
           "exemplar": true,
           "expr": "count (confluent_kafka_server_partition_count)",
           "format": "time_series",
@@ -113,7 +110,7 @@
       "type": "gauge"
     },
     {
-      "datasource": "Prometheus",
+      : "Prometheus",
       "description": "The number of registered schemas",
       "fieldConfig": {
         "defaults": {
@@ -161,7 +158,7 @@
       "pluginVersion": "8.1.3",
       "targets": [
         {
-          "datasource": "Prometheus",
+          : "Prometheus",
           "exemplar": true,
           "expr": "count(confluent_kafka_connect_sent_bytes)",
           "format": "time_series",
@@ -177,7 +174,7 @@
       "type": "gauge"
     },
     {
-      "datasource": "Prometheus",
+      : "Prometheus",
       "description": "The number of registered schemas",
       "fieldConfig": {
         "defaults": {
@@ -225,7 +222,7 @@
       "pluginVersion": "8.1.3",
       "targets": [
         {
-          "datasource": "Prometheus",
+          : "Prometheus",
           "exemplar": true,
           "expr": "count(confluent_kafka_ksql_streaming_unit_count)",
           "format": "time_series",
@@ -241,7 +238,7 @@
       "type": "gauge"
     },
     {
-      "datasource": "Prometheus",
+      : "Prometheus",
       "description": "The number of registered schemas",
       "fieldConfig": {
         "defaults": {
@@ -289,7 +286,7 @@
       "pluginVersion": "8.1.3",
       "targets": [
         {
-          "datasource": "Prometheus",
+          : "Prometheus",
           "exemplar": true,
           "expr": "confluent_kafka_schema_registry_schema_count",
           "format": "time_series",
@@ -303,7 +300,7 @@
       "type": "gauge"
     },
     {
-      "datasource": "Prometheus",
+      : "Prometheus",
       "description": "Basic clusters have a max retained bytes limit of 5 TB prior to replication. ccloud_metrics_retained_bytes is after replication thus needs to be divided by 3.",
       "fieldConfig": {
         "defaults": {
@@ -359,7 +356,7 @@
       "pluginVersion": "8.1.3",
       "targets": [
         {
-          "datasource": "Prometheus",
+          : "Prometheus",
           "expr": "sum(confluent_kafka_server_retained_bytes{topic=~\"$topic\", kafka_id=~\"$cluster\"})/3",
           "interval": "",
           "legendFormat": "{{cluster}}",
@@ -370,7 +367,7 @@
       "type": "stat"
     },
     {
-      "datasource": "Prometheus",
+      : "Prometheus",
       "description": "Per-second average rate of ingress of data to topics, basic cluster has a max of 100MBps.",
       "fieldConfig": {
         "defaults": {
@@ -425,7 +422,7 @@
       "pluginVersion": "8.1.3",
       "targets": [
         {
-          "datasource": "Prometheus",
+          : "Prometheus",
           "editorMode": "code",
           "exemplar": true,
           "expr": "sum(rate(confluent_kafka_server_received_bytes{topic=~\"$topic\", kafka_id=~\"$cluster\"}[1m]))",
@@ -439,7 +436,7 @@
       "type": "stat"
     },
     {
-      "datasource": "Prometheus",
+      : "Prometheus",
       "description": "Per-second average rate of egress data to topics, basic cluster has a max of 100MBps.",
       "fieldConfig": {
         "defaults": {
@@ -494,7 +491,7 @@
       "pluginVersion": "8.1.3",
       "targets": [
         {
-          "datasource": "Prometheus",
+          : "Prometheus",
           "disableTextWrap": false,
           "editorMode": "code",
           "exemplar": false,
@@ -513,7 +510,7 @@
       "type": "stat"
     },
     {
-      "datasource": "Prometheus",
+      : "Prometheus",
       "description": "Per-second average rate of requests, basic cluster maxes out at 1500 requests per second.",
       "fieldConfig": {
         "defaults": {
@@ -569,7 +566,7 @@
       "pluginVersion": "8.1.3",
       "targets": [
         {
-          "datasource": "Prometheus",
+          : "Prometheus",
           "editorMode": "code",
           "expr": "sum(rate(confluent_kafka_server_request_count{type=~\".*\", kafka_id=~\"$cluster\"}[1m]))",
           "interval": "",
@@ -582,7 +579,7 @@
       "type": "stat"
     },
     {
-      "datasource": "Prometheus",
+      : "Prometheus",
       "description": "The average active connections to a cluster. Basic clusters limit active connections to 1000.",
       "fieldConfig": {
         "defaults": {
@@ -639,7 +636,7 @@
       "pluginVersion": "8.1.3",
       "targets": [
         {
-          "datasource": "Prometheus",
+          : "Prometheus",
           "expr": "avg(confluent_kafka_server_active_connection_count{kafka_id=~\"$cluster\"})",
           "hide": false,
           "interval": "",
@@ -651,7 +648,7 @@
       "type": "stat"
     },
     {
-      "datasource": "Prometheus",
+      : "Prometheus",
       "description": "The sum of partitions in a cluster. Basic cluster max partitions limit is 2048.",
       "fieldConfig": {
         "defaults": {
@@ -735,7 +732,7 @@
       "pluginVersion": "8.1.3",
       "targets": [
         {
-          "datasource": "Prometheus",
+          : "Prometheus",
           "exemplar": true,
           "expr": "confluent_kafka_server_partition_count{kafka_id=~\"$cluster\"}",
           "hide": false,
@@ -748,7 +745,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": "Prometheus",
+      : "Prometheus",
       "description": "Basic clusters have a limit on the number of partitions that can be created and deleted in a 5 minute period. This single stat provides the absolute difference between the number of partitions are the beginning and end of the 5 minute period. This over simplifies the problem, so more conservative thresholds are put in place. ",
       "fieldConfig": {
         "defaults": {
@@ -832,7 +829,7 @@
       "pluginVersion": "8.1.3",
       "targets": [
         {
-          "datasource": "Prometheus",
+          : "Prometheus",
           "exemplar": true,
           "expr": "abs(delta(confluent_kafka_server_partition_count{kafka_id=~\"$cluster\"}[5m]))",
           "format": "time_series",
@@ -848,7 +845,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": "Prometheus",
+      : "Prometheus",
       "description": "The lag between a group member's committed offset and the partition's high watermark.",
       "fieldConfig": {
         "defaults": {
@@ -925,7 +922,7 @@
       "pluginVersion": "8.3.3",
       "targets": [
         {
-          "datasource": "Prometheus",
+          : "Prometheus",
           "exemplar": true,
           "expr": "sum by (consumer_group_id, topic) (confluent_kafka_server_consumer_lag_offsets{topic=~\"$topic\", kafka_id=~\"$cluster\"})",
           "hide": false,
@@ -938,7 +935,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": "Prometheus",
+      : "Prometheus",
       "description": "The average active connections to a cluster. Basic clusters limit active connections to 1000.",
       "fieldConfig": {
         "defaults": {
@@ -1015,7 +1012,7 @@
       "pluginVersion": "8.3.3",
       "targets": [
         {
-          "datasource": "Prometheus",
+          : "Prometheus",
           "exemplar": true,
           "expr": "confluent_kafka_server_successful_authentication_count{}",
           "hide": false,
@@ -1029,7 +1026,7 @@
     },
     {
       "collapsed": false,
-      "datasource": "Prometheus",
+      : "Prometheus",
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -1040,7 +1037,7 @@
       "panels": [],
       "targets": [
         {
-          "datasource": "Prometheus",
+          : "Prometheus",
           "refId": "A"
         }
       ],
@@ -1052,7 +1049,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      : "Prometheus",
       "description": "The current count of bytes retained by the cluster, summed across all partitions. The count is sampled every 60 seconds.",
       "fieldConfig": {
         "defaults": {
@@ -1100,7 +1097,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "datasource": "Prometheus",
+          : "Prometheus",
           "expr": "sum by (kafka_id, topic) (confluent_kafka_server_retained_bytes{topic=~\"$topic\", kafka_id=~\"$cluster\"})",
           "hide": false,
           "interval": "",
@@ -1145,7 +1142,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      : "Prometheus",
       "description": "The delta count of bytes received from the network. Each sample is the number of bytes received since the previous data sample. The count is sampled every 60 seconds.",
       "fieldConfig": {
         "defaults": {
@@ -1189,7 +1186,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "datasource": "Prometheus",
+          : "Prometheus",
           "expr": "sum by (topic, kafka_id) (confluent_kafka_server_received_bytes{topic=~\"$topic\", kafka_id=~\"$cluster\"})",
           "hide": false,
           "interval": "",
@@ -1234,7 +1231,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      : "Prometheus",
       "description": "The delta count of bytes sent over the network. Each sample is the number of bytes sent since the previous data point. The count is sampled every 60 seconds.",
       "fieldConfig": {
         "defaults": {
@@ -1280,7 +1277,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "datasource": "Prometheus",
+          : "Prometheus",
           "expr": "sum by (topic, kafka_id) (confluent_kafka_server_sent_bytes{topic=~\"$topic\", kafka_id=~\"$cluster\"})",
           "hide": false,
           "interval": "",
@@ -1325,7 +1322,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      : "Prometheus",
       "description": "The delta count of records received. Each sample is the number of records received since the previous data sample. The count is sampled every 60 seconds.",
       "fieldConfig": {
         "defaults": {
@@ -1369,7 +1366,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "datasource": "Prometheus",
+          : "Prometheus",
           "expr": "sum by (topic, kafka_id) (confluent_kafka_server_received_records{topic=~\"$topic\", kafka_id=~\"$cluster\"})",
           "hide": false,
           "interval": "",
@@ -1412,7 +1409,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      : "Prometheus",
       "description": "The delta count of records sent. Each sample is the number of records sent since the previous data point. The count is sampled every 60 seconds.",
       "fieldConfig": {
         "defaults": {
@@ -1456,7 +1453,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "datasource": "Prometheus",
+          : "Prometheus",
           "expr": "sum by (topic, kafka_id) (confluent_kafka_server_sent_records{topic=~\"$topic\", kafka_id=~\"$cluster\"})",
           "hide": false,
           "interval": "",
@@ -1499,7 +1496,7 @@
       "bars": true,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      : "Prometheus",
       "description": "The delta count of requests received over the network. Each sample is the number of requests received since the previous data point. The count sampled every 60 seconds.",
       "fieldConfig": {
         "defaults": {

--- a/ccloud-prometheus-grafana/assets/grafana/provisioning/dashboards/ccloud.json
+++ b/ccloud-prometheus-grafana/assets/grafana/provisioning/dashboards/ccloud.json
@@ -2133,7 +2133,6 @@
       "pluginVersion": "8.1.3",
       "targets": [
         {
-          "datasource": "Prometheus",
           "expr": "count(confluent_kafka_ksql_streaming_unit_count)",
           "interval": "",
           "legendFormat": "",
@@ -2155,12 +2154,6 @@
       },
       "id": 25,
       "panels": [],
-      "targets": [
-        {
-          "datasource": "Prometheus",
-          "refId": "A"
-        }
-      ],
       "title": "Metrics API",
       "type": "row"
     },
@@ -2247,7 +2240,6 @@
       "steppedLine": false,
       "targets": [
         {
-          "datasource": "Prometheus",
           "expr": "scrape_duration_seconds{job=\"Confluent Cloud\"}",
           "interval": "",
           "legendFormat": "{{instance}}",
@@ -2290,12 +2282,13 @@
         }
       ],
       "yaxis": {
-        "align": false
+        "align": false,
+        "alignLevel": null
       }
     }
   ],
-  "refresh": "1m",
-  "schemaVersion": 38,
+  "refresh": "5s",
+  "schemaVersion": 30,
   "style": "dark",
   "tags": [],
   "templating": {
@@ -2367,7 +2360,7 @@
     ]
   },
   "time": {
-    "from": "now-30m",
+    "from": "now-1h",
     "to": "now"
   },
   "timepicker": {
@@ -2387,6 +2380,5 @@
   "timezone": "",
   "title": "Confluent Cloud",
   "uid": "fhX5408Zk",
-  "version": 9,
-  "weekStart": ""
+  "version": 6
 }

--- a/ccloud-prometheus-grafana/assets/grafana/provisioning/dashboards/ccloud.json
+++ b/ccloud-prometheus-grafana/assets/grafana/provisioning/dashboards/ccloud.json
@@ -30,10 +30,7 @@
   "panels": [
     {
       "collapsed": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
-      },
+      "datasource": "Prometheus",
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -44,10 +41,7 @@
       "panels": [],
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
-          },
+          "datasource": "Prometheus",
           "refId": "A"
         }
       ],
@@ -55,10 +49,7 @@
       "type": "row"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
-      },
+      "datasource": "Prometheus",
       "description": "The number of registered schemas",
       "fieldConfig": {
         "defaults": {
@@ -106,10 +97,7 @@
       "pluginVersion": "10.1.2",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "count (confluent_kafka_server_partition_count)",
           "format": "time_series",
@@ -125,10 +113,7 @@
       "type": "gauge"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
-      },
+      "datasource": "Prometheus",
       "description": "The number of registered schemas",
       "fieldConfig": {
         "defaults": {
@@ -176,10 +161,7 @@
       "pluginVersion": "10.1.2",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "count(confluent_kafka_connect_sent_bytes)",
           "format": "time_series",
@@ -195,10 +177,7 @@
       "type": "gauge"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
-      },
+      "datasource": "Prometheus",
       "description": "The number of registered schemas",
       "fieldConfig": {
         "defaults": {
@@ -246,10 +225,7 @@
       "pluginVersion": "10.1.2",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "count(confluent_kafka_ksql_streaming_unit_count)",
           "format": "time_series",
@@ -265,10 +241,7 @@
       "type": "gauge"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
-      },
+      "datasource": "Prometheus",
       "description": "The number of registered schemas",
       "fieldConfig": {
         "defaults": {
@@ -316,10 +289,7 @@
       "pluginVersion": "10.1.2",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "confluent_kafka_schema_registry_schema_count",
           "format": "time_series",
@@ -333,10 +303,7 @@
       "type": "gauge"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
-      },
+      "datasource": "Prometheus",
       "description": "Basic clusters have a max retained bytes limit of 5 TB prior to replication. ccloud_metrics_retained_bytes is after replication thus needs to be divided by 3.",
       "fieldConfig": {
         "defaults": {
@@ -392,10 +359,7 @@
       "pluginVersion": "10.1.2",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
-          },
+          "datasource": "Prometheus",
           "expr": "sum(confluent_kafka_server_retained_bytes{topic=~\"$topic\", kafka_id=~\"$cluster\"})/3",
           "interval": "",
           "legendFormat": "{{cluster}}",
@@ -406,10 +370,7 @@
       "type": "stat"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
-      },
+      "datasource": "Prometheus",
       "description": "Per-second average rate of ingress of data to topics, basic cluster has a max of 100MBps.",
       "fieldConfig": {
         "defaults": {
@@ -464,10 +425,7 @@
       "pluginVersion": "10.1.2",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
-          },
+          "datasource": "Prometheus",
           "editorMode": "code",
           "exemplar": true,
           "expr": "sum(rate(confluent_kafka_server_received_bytes{topic=~\"$topic\", kafka_id=~\"$cluster\"}[1m]))",
@@ -481,10 +439,7 @@
       "type": "stat"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
-      },
+      "datasource": "Prometheus",
       "description": "Per-second average rate of egress data to topics, basic cluster has a max of 100MBps.",
       "fieldConfig": {
         "defaults": {
@@ -539,10 +494,7 @@
       "pluginVersion": "10.1.2",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
-          },
+          "datasource": "Prometheus",
           "disableTextWrap": false,
           "editorMode": "code",
           "exemplar": false,
@@ -561,10 +513,7 @@
       "type": "stat"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
-      },
+      "datasource": "Prometheus",
       "description": "Per-second average rate of requests, basic cluster maxes out at 1500 requests per second.",
       "fieldConfig": {
         "defaults": {
@@ -620,10 +569,7 @@
       "pluginVersion": "10.1.2",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
-          },
+          "datasource": "Prometheus",
           "editorMode": "code",
           "expr": "sum(rate(confluent_kafka_server_request_count{type=~\".*\", kafka_id=~\"$cluster\"}[1m]))",
           "interval": "",
@@ -636,10 +582,7 @@
       "type": "stat"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
-      },
+      "datasource": "Prometheus",
       "description": "The average active connections to a cluster. Basic clusters limit active connections to 1000.",
       "fieldConfig": {
         "defaults": {
@@ -696,10 +639,7 @@
       "pluginVersion": "10.1.2",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
-          },
+          "datasource": "Prometheus",
           "expr": "avg(confluent_kafka_server_active_connection_count{kafka_id=~\"$cluster\"})",
           "hide": false,
           "interval": "",
@@ -711,10 +651,7 @@
       "type": "stat"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
-      },
+      "datasource": "Prometheus",
       "description": "The sum of partitions in a cluster. Basic cluster max partitions limit is 2048.",
       "fieldConfig": {
         "defaults": {
@@ -798,10 +735,7 @@
       "pluginVersion": "8.1.3",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "confluent_kafka_server_partition_count{kafka_id=~\"$cluster\"}",
           "hide": false,
@@ -814,10 +748,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
-      },
+      "datasource": "Prometheus",
       "description": "Basic clusters have a limit on the number of partitions that can be created and deleted in a 5 minute period. This single stat provides the absolute difference between the number of partitions are the beginning and end of the 5 minute period. This over simplifies the problem, so more conservative thresholds are put in place. ",
       "fieldConfig": {
         "defaults": {
@@ -901,10 +832,7 @@
       "pluginVersion": "8.1.3",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "abs(delta(confluent_kafka_server_partition_count{kafka_id=~\"$cluster\"}[5m]))",
           "format": "time_series",
@@ -920,10 +848,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
-      },
+      "datasource": "Prometheus",
       "description": "The lag between a group member's committed offset and the partition's high watermark.",
       "fieldConfig": {
         "defaults": {
@@ -1000,10 +925,7 @@
       "pluginVersion": "8.3.3",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "sum by (consumer_group_id, topic) (confluent_kafka_server_consumer_lag_offsets{topic=~\"$topic\", kafka_id=~\"$cluster\"})",
           "hide": false,
@@ -1016,10 +938,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
-      },
+      "datasource": "Prometheus",
       "description": "The average active connections to a cluster. Basic clusters limit active connections to 1000.",
       "fieldConfig": {
         "defaults": {
@@ -1096,10 +1015,7 @@
       "pluginVersion": "8.3.3",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "confluent_kafka_server_successful_authentication_count{}",
           "hide": false,
@@ -1113,10 +1029,7 @@
     },
     {
       "collapsed": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
-      },
+      "datasource": "Prometheus",
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -1127,10 +1040,7 @@
       "panels": [],
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
-          },
+          "datasource": "Prometheus",
           "refId": "A"
         }
       ],
@@ -1142,10 +1052,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
-      },
+      "datasource": "Prometheus",
       "description": "The current count of bytes retained by the cluster, summed across all partitions. The count is sampled every 60 seconds.",
       "fieldConfig": {
         "defaults": {
@@ -1193,10 +1100,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
-          },
+          "datasource": "Prometheus",
           "expr": "sum by (kafka_id, topic) (confluent_kafka_server_retained_bytes{topic=~\"$topic\", kafka_id=~\"$cluster\"})",
           "hide": false,
           "interval": "",
@@ -1241,10 +1145,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
-      },
+      "datasource": "Prometheus",
       "description": "The delta count of bytes received from the network. Each sample is the number of bytes received since the previous data sample. The count is sampled every 60 seconds.",
       "fieldConfig": {
         "defaults": {
@@ -1288,10 +1189,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
-          },
+          "datasource": "Prometheus",
           "expr": "sum by (topic, kafka_id) (confluent_kafka_server_received_bytes{topic=~\"$topic\", kafka_id=~\"$cluster\"})",
           "hide": false,
           "interval": "",
@@ -1336,10 +1234,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
-      },
+      "datasource": "Prometheus",
       "description": "The delta count of bytes sent over the network. Each sample is the number of bytes sent since the previous data point. The count is sampled every 60 seconds.",
       "fieldConfig": {
         "defaults": {
@@ -1385,10 +1280,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
-          },
+          "datasource": "Prometheus",
           "expr": "sum by (topic, kafka_id) (confluent_kafka_server_sent_bytes{topic=~\"$topic\", kafka_id=~\"$cluster\"})",
           "hide": false,
           "interval": "",
@@ -1433,10 +1325,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
-      },
+      "datasource": "Prometheus",
       "description": "The delta count of records received. Each sample is the number of records received since the previous data sample. The count is sampled every 60 seconds.",
       "fieldConfig": {
         "defaults": {
@@ -1480,10 +1369,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
-          },
+          "datasource": "Prometheus",
           "expr": "sum by (topic, kafka_id) (confluent_kafka_server_received_records{topic=~\"$topic\", kafka_id=~\"$cluster\"})",
           "hide": false,
           "interval": "",
@@ -1526,10 +1412,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
-      },
+      "datasource": "Prometheus",
       "description": "The delta count of records sent. Each sample is the number of records sent since the previous data point. The count is sampled every 60 seconds.",
       "fieldConfig": {
         "defaults": {
@@ -1573,10 +1456,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
-          },
+          "datasource": "Prometheus",
           "expr": "sum by (topic, kafka_id) (confluent_kafka_server_sent_records{topic=~\"$topic\", kafka_id=~\"$cluster\"})",
           "hide": false,
           "interval": "",
@@ -1619,10 +1499,7 @@
       "bars": true,
       "dashLength": 10,
       "dashes": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
-      },
+      "datasource": "Prometheus",
       "description": "The delta count of requests received over the network. Each sample is the number of requests received since the previous data point. The count sampled every 60 seconds.",
       "fieldConfig": {
         "defaults": {
@@ -1670,10 +1547,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
-          },
+          "datasource": "Prometheus",
           "expr": "confluent_kafka_server_request_count{kafka_id=~\"$cluster\"}",
           "hide": false,
           "interval": "",
@@ -1713,10 +1587,7 @@
     },
     {
       "collapsed": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
-      },
+      "datasource": "Prometheus",
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -1727,10 +1598,7 @@
       "panels": [],
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
-          },
+          "datasource": "Prometheus",
           "refId": "A"
         }
       ],
@@ -1742,10 +1610,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
-      },
+      "datasource": "Prometheus",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -1782,10 +1647,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
-          },
+          "datasource": "Prometheus",
           "expr": "confluent_kafka_connect_sent_records{connector_id=~\"$cluster\"}",
           "interval": "",
           "legendFormat": "{{connector_id}} -- {{connector_id}}",
@@ -1828,10 +1690,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
-      },
+      "datasource": "Prometheus",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -1868,10 +1727,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
-          },
+          "datasource": "Prometheus",
           "expr": "confluent_kafka_connect_received_bytes{connector_id=~\"$cluster\"}",
           "interval": "",
           "legendFormat": "{{connector_id}} -- {{connector_id}}",
@@ -1914,10 +1770,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
-      },
+      "datasource": "Prometheus",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -1954,10 +1807,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "confluent_kafka_connect_dead_letter_queue_records{connector_id=~\"$cluster\"}",
           "interval": "",
@@ -2004,10 +1854,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
-      },
+      "datasource": "Prometheus",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -2044,10 +1891,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
-          },
+          "datasource": "Prometheus",
           "expr": "confluent_kafka_connect_sent_bytes{connector_id=~\"$cluster\"}",
           "interval": "",
           "legendFormat": "{{connector_id}} -- {{connector_id}}",
@@ -2090,10 +1934,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
-      },
+      "datasource": "Prometheus",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -2130,10 +1971,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
-          },
+          "datasource": "Prometheus",
           "expr": "confluent_kafka_connect_received_records{connector_id=~\"$cluster\"}",
           "interval": "",
           "legendFormat": "{{connector_id}} -- {{connector_id}}",
@@ -2173,10 +2011,7 @@
     },
     {
       "collapsed": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
-      },
+      "datasource": "Prometheus",
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -2187,10 +2022,7 @@
       "panels": [],
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
-          },
+          "datasource": "Prometheus",
           "refId": "A"
         }
       ],
@@ -2198,10 +2030,7 @@
       "type": "row"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
-      },
+      "datasource": "Prometheus",
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -2246,10 +2075,7 @@
       "pluginVersion": "8.1.3",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "confluent_kafka_ksql_streaming_unit_count",
           "interval": "",
@@ -2262,10 +2088,7 @@
       "type": "stat"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
-      },
+      "datasource": "Prometheus",
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -2310,10 +2133,7 @@
       "pluginVersion": "8.1.3",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
-          },
+          "datasource": "Prometheus",
           "expr": "count(confluent_kafka_ksql_streaming_unit_count)",
           "interval": "",
           "legendFormat": "",
@@ -2326,10 +2146,7 @@
     },
     {
       "collapsed": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
-      },
+      "datasource": "Prometheus",
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -2340,10 +2157,7 @@
       "panels": [],
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
-          },
+          "datasource": "Prometheus",
           "refId": "A"
         }
       ],
@@ -2390,10 +2204,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
-      },
+      "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": {
           "links": []
@@ -2436,10 +2247,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
-          },
+          "datasource": "Prometheus",
           "expr": "scrape_duration_seconds{job=\"Confluent Cloud\"}",
           "interval": "",
           "legendFormat": "{{instance}}",
@@ -2503,10 +2311,7 @@
             "$__all"
           ]
         },
-        "datasource": {
-          "type": "prometheus",
-          "uid": "PBFA97CFB590B2093"
-        },
+        "datasource": "Prometheus",
         "definition": "label_values(confluent_kafka_server_retained_bytes, kafka_id)",
         "hide": 0,
         "includeAll": true,
@@ -2538,10 +2343,7 @@
             "$__all"
           ]
         },
-        "datasource": {
-          "type": "prometheus",
-          "uid": "PBFA97CFB590B2093"
-        },
+        "datasource": "Prometheus",
         "definition": "label_values(confluent_kafka_server_retained_bytes, topic)",
         "hide": 0,
         "includeAll": true,


### PR DESCRIPTION

| Item | Changes |
|--|--|
| Write on Topics | Change from Graph widget to Stats (since graph exists below and total ingress/sec doesn't exist) |
| Read on Topics | Change from Graph widget to Stats (since graph exists below and total egress/sec doesn't exist)  |
| Request (rate) | Change title to `Request Count (rate)` from `Request (rate)` |


**Before**
![Screenshot 2023-09-27 at 11 13 24](https://github.com/confluentinc/jmx-monitoring-stacks/assets/6927131/d6f9135b-e283-4f5a-8ab5-7019936b0205)

**After**

![Screenshot 2023-09-27 at 11 27 53](https://github.com/confluentinc/jmx-monitoring-stacks/assets/6927131/23148f28-070e-4beb-8cef-7deff0f70573)
