### PR TITLE
Correctly populate Grafana variables in Kafka Connect dashboard

### DIFF
--- a/jmxexporter-prometheus-grafana/assets/grafana/provisioning/dashboards/kafka-connect-cluster.json
+++ b/jmxexporter-prometheus-grafana/assets/grafana/provisioning/dashboards/kafka-connect-cluster.json
@@ -5460,7 +5460,7 @@
           "value": "dev"
         },
         "datasource": "Prometheus",
-        "definition": "label_values(env)",
+        "definition": "label_values(kafka_connect_app_info,env)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -5470,7 +5470,7 @@
         "name": "env",
         "options": [],
         "query": {
-          "query": "label_values(env)",
+          "query": "label_values(kafka_connect_app_info,env)",
           "refId": "Prometheus-env-Variable-Query"
         },
         "refresh": 1,
@@ -5494,7 +5494,7 @@
           ]
         },
         "datasource": "Prometheus",
-        "definition": "label_values(kafka_connect_cluster_id)",
+        "definition": "label_values(kafka_connect_app_info,kafka_connect_cluster_id)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -5504,7 +5504,7 @@
         "name": "kafka_connect_cluster_id",
         "options": [],
         "query": {
-          "query": "label_values(kafka_connect_cluster_id)",
+          "query": "label_values(kafka_connect_app_info,kafka_connect_cluster_id)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,


### PR DESCRIPTION
**Why**

If the env and cluster ID are specified in Prometheus metric collection config, the metrics do not show up properly in Grafana.

**Expected**

The variables should be set dynamically from the available metrics.

**Reproduce Steps**

1. Set up Kafka Connector with [this JMX exporter][1]
2. Create a prometheus file with this configuration

```sh
  - job_name: "kafka-connect"
    sample_limit: 10000
    scrape_interval: 1m
    scrape_timeout: 55s
    honor_timestamps: true
    static_configs:
      - targets:
        - connect-0.connect.confluent.svc.cluster.local:7778
        - connect-1.connect.confluent.svc.cluster.local:7778
        labels:
          env: "prod"
          kafka_connect_cluster_id: "mycluster"
    scheme: http
    metrics_path: /metrics
    relabel_configs:
      - source_labels: [__address__]
        target_label: hostname
        regex: '([^:]+)(:[0-9]+)?'
        replacement: '${1}'
```

3. Connect to prometheus using [this grafana dashboard ][2]
4. Notice `env` and `kafka_connect_cluster_id` are not loaded. Also dashboard widgets are showing 0 since these filtering values are not populated.

**Changes**

| Item | Before | After |
|--|--|--|
| Env |  ![Screenshot 2023-09-27 at 13 02 48](https://github.com/confluentinc/jmx-monitoring-stacks/assets/6927131/8f24a694-981c-4f5d-8eed-67b27d414acb) | ![Screenshot 2023-09-27 at 13 05 24](https://github.com/confluentinc/jmx-monitoring-stacks/assets/6927131/6ed8c2d3-8abe-406c-b8da-e4ba5144a0eb)
| Cluster ID | ![Screenshot 2023-09-27 at 13 02 44](https://github.com/confluentinc/jmx-monitoring-stacks/assets/6927131/900448c6-6774-417a-8100-a60b032aebc8) | ![Screenshot 2023-09-27 at 13 05 22](https://github.com/confluentinc/jmx-monitoring-stacks/assets/6927131/de76db21-e5a0-4ee1-a19c-7878aaa9ec0f)



[1]: https://github.com/confluentinc/jmx-monitoring-stacks/blob/main/shared-assets/jmx-exporter/kafka_connect.yml
[2]: https://github.com/confluentinc/jmx-monitoring-stacks/blob/main/jmxexporter-prometheus-grafana/assets/grafana/provisioning/dashboards/kafka-connect-cluster.json