### PR TITLE
Correctly use Total Schemas

### DIFF
--- a/ccloud-prometheus-grafana/assets/grafana/provisioning/dashboards/ccloud.json
+++ b/ccloud-prometheus-grafana/assets/grafana/provisioning/dashboards/ccloud.json
@@ -294,7 +294,7 @@
           "refId": "A"
         }
       ],
-      "title": "Total Schema Registry Instances",
+      "title": "Total Schemas",
       "type": "gauge"
     },
     {


### PR DESCRIPTION
**Why**

The text shown in dashboard is an incorrect representation of schema registry instances. The number of instances is not exposed to the outside world. [reference][1] However, the metrics used refers to the total number of schemas. [source][3]

**Expected**

The text should be `Total Schemas`

**Observed**

The text is `Total Schema Registry Instances`

**Reproduce Steps**

1. setup prometheus
1. setup grafana
1. create confluent cloud dashboard from [7.2-post][2]
1. Notice the total schema registry instances shows 

**Changes**

| Before | After |
|--|--|
|  ![Screenshot 2023-09-27 at 13 53 32](https://github.com/confluentinc/jmx-monitoring-stacks/assets/6927131/19e4be35-7ad2-41e2-87f3-da730f8f1a05)  | ![Screenshot 2023-09-27 at 13 54 43](https://github.com/confluentinc/jmx-monitoring-stacks/assets/6927131/57fd9e51-229c-45ba-aaf2-95ffee8d3e56)


[1]: https://api.telemetry.confluent.cloud/docs/descriptors/datasets/cloud
[2]: https://github.com/confluentinc/jmx-monitoring-stacks/blob/7.2-post/ccloud-prometheus-grafana/assets/grafana/provisioning/dashboards/ccloud.json
[3]: https://github.com/confluentinc/jmx-monitoring-stacks/blob/7.2-post/ccloud-prometheus-grafana/assets/grafana/provisioning/dashboards/ccloud.json#L289