### PR TITLE
Rebalance metrics should be job=kafka-connect

### DIFF
--- a/jmxexporter-prometheus-grafana/assets/grafana/provisioning/dashboards/kafka-connect-cluster.json
+++ b/jmxexporter-prometheus-grafana/assets/grafana/provisioning/dashboards/kafka-connect-cluster.json
@@ -3396,7 +3396,7 @@
           "repeat": "instance",
           "targets": [
             {
-              "expr": "kafka_connect_connect_worker_rebalance_metrics_time_since_last_rebalance_ms{job=\"kafka-connect\", env=\"$env\",instance=~\"$instance\",job=\"connect\",kafka_connect_cluster_id=~\"$kafka_connect_cluster_id\"} >= 0",
+              "expr": "kafka_connect_connect_worker_rebalance_metrics_time_since_last_rebalance_ms{job=\"kafka-connect\", env=\"$env\",instance=~\"$instance\",job=\"kafka-connect\",kafka_connect_cluster_id=~\"$kafka_connect_cluster_id\"} >= 0",
               "format": "time_series",
               "instant": false,
               "interval": "",


### PR DESCRIPTION
Rebalance metrics do not show since the job name is `connect` instead of `kafka-connect`.

| Before | After |
|--|--|
| ![Screenshot 2023-10-23 at 19 12 29](https://github.com/confluentinc/jmx-monitoring-stacks/assets/6927131/dc66ac6e-9fc9-4c7f-82db-975024da0d51) |  ![Screenshot 2023-10-23 at 19 12 22](https://github.com/confluentinc/jmx-monitoring-stacks/assets/6927131/716c04d0-9903-4782-9b5b-44bb3ec39b13)
