### PR TITLE
Don't use cache in kafka connect jmx exporter

### DIFF
--- a/shared-assets/jmx-exporter/kafka_connect.yml
+++ b/shared-assets/jmx-exporter/kafka_connect.yml
@@ -40,7 +40,6 @@ rules:
   - pattern: "kafka.connect<type=app-info, client-id=(.+)><>(.+): (.+)"
     name: "kafka_connect_app_info"
     value: 1
-    cache: true
     labels:
       client-id: "$1"
       $2: "$3"
@@ -52,26 +51,22 @@ rules:
   # kafka.connect:type=connect-metrics,client-id=*
   - pattern: "kafka.connect<type=(.+), client-id=(.+)><>([^:]+)"
     name: kafka_connect_$1_$3
-    cache: true
     labels:
       client_id: $2
   # kafka.connect:type=connect-worker-metrics
   - pattern: "kafka.connect<type=connect-worker-metrics><>([^:]+)"
     name: kafka_connect_connect_worker_metrics_$1
-    cache: true
     labels:
       connector: "aggregate"
   # kafka.connect:type=connect-worker-metrics,connector=*
   - pattern: "kafka.connect<type=connect-worker-metrics, connector=(.+)><>([^:]+)"
     name: kafka_connect_connect_worker_metrics_$2
-    cache: true
     labels:
       connector: $1
   # kafka.connect:type=connector-metrics,connector=*
   - pattern: "kafka.connect<type=connector-metrics, connector=(.+)><>(.+): (.+)"
     value: 1
     name: kafka_connect_connector_metrics
-    cache: true
     labels:
       connector: $1
       $2: $3
@@ -82,7 +77,6 @@ rules:
   # kafka.connect:type=connector-task-metrics,connector=*,task=*
   - pattern: "kafka.connect<type=(.+)-task-metrics, connector=(.+), task=(\\d+)><>(.+): (.+)"
     name: kafka_connect_$1_task_metrics_$4
-    cache: true
     labels:
       connector: "$2"
       task: "$3"
@@ -90,14 +84,12 @@ rules:
   # kafka.connect:type=task-error-metrics,connector=*,task=*
   - pattern: "kafka.connect<type=task-error-metrics, connector=(.+), task=(\\d+)><>([^:]+)"
     name: kafka_connect_task_error_metrics_$3
-    cache: true
     labels:
       connector: "$1"
       task: "$2"
   # confluent.replicator:type=confluent-replicator-task-metrics,* : confluent-replicator-task-topic-partition-*: Number Values
   - pattern: "confluent.replicator<type=confluent-replicator-task-metrics, confluent-replicator-(.*)=(.+), confluent-replicator-(.+)=(.+), confluent-replicator-(.+)=(.+), confluent-replicator-(.+)=(.+)><>confluent-replicator-task-topic-partition-(.*): (.*)"
     name: confluent_replicator_task_metrics_$9
-    cache: true
     labels:
       $1: "$2"
       $3: "$4"
@@ -107,7 +99,6 @@ rules:
   - pattern: "confluent.replicator<type=confluent-replicator-task-metrics, confluent-replicator-(.*)=(.+), confluent-replicator-(.+)=(.+), confluent-replicator-(.+)=(.+), confluent-replicator-(.+)=(.+)><>(confluent-replicator-destination-cluster|confluent-replicator-source-cluster|confluent-replicator-destination-topic-name): (.*)"
     name: confluent_replicator_task_metrics_info
     value: 1
-    cache: true
     labels:
       $1: "$2"
       $3: "$4"
@@ -119,7 +110,6 @@ rules:
   - pattern: "kafka.(.+)<type=app-info, client-id=(.+)><>(.+): (.+)"
     value: 1
     name: kafka_$1_app_info
-    cache: true
     labels:
       client_type: $1
       client_id: $2
@@ -131,7 +121,6 @@ rules:
   - pattern: "kafka.(.+)<type=(.+), (.+)=(.+), (.+)=(.+), (.+)=(.+)><>(.+):"
     name: kafka_$1_$2_$9
     type: GAUGE
-    cache: true
     labels:
       client_type: $1
       $3: "$4"
@@ -144,7 +133,6 @@ rules:
   - pattern: "kafka.(.+)<type=(.+), (.+)=(.+), (.+)=(.+)><>(.+):"
     name: kafka_$1_$2_$7
     type: GAUGE
-    cache: true
     labels:
       client_type: $1
       $3: "$4"
@@ -155,12 +143,10 @@ rules:
   - pattern: "kafka.(.+)<type=(.+), (.+)=(.+)><>(.+):"
     name: kafka_$1_$2_$5
     type: GAUGE
-    cache: true
     labels:
       client_type: $1
       $3: "$4"
   - pattern: "kafka.(.+)<type=(.+)><>(.+):"
     name: kafka_$1_$2_$3
-    cache: true
     labels:
       client_type: $1


### PR DESCRIPTION
**Why**

Using `cache: true` can make some JMX values show up like this: `<cache>` in the HTTP endpoint, causing the dashboard to not show up correctly.

**Expected**

It should not break dashboard by retrieving correct values.

[no-cache-kafka-connect-jmx.txt](https://github.com/confluentinc/jmx-monitoring-stacks/files/13069755/no-cache-kafka-connect-jmx.txt)

![Screenshot 2023-10-23 at 21 01 34](https://github.com/confluentinc/jmx-monitoring-stacks/assets/6927131/8f6137be-bacb-450f-a3a2-8d53be6ff5f1)

**Observed**

It breaks dashboard by retrieving `<cache>` values.

[cached-kafka-connect-jmx.txt](https://github.com/confluentinc/jmx-monitoring-stacks/files/13069754/cached-kafka-connect-jmx.txt)

![Screenshot 2023-10-23 at 20 47 54](https://github.com/confluentinc/jmx-monitoring-stacks/assets/6927131/c89ce93b-7e89-4809-a9bb-baec976199a4)

