### PR TITLE
Set explicit prometheus datasource and remove uid

### DIFF
--- a/ccloud-prometheus-grafana/assets/grafana/provisioning/dashboards/ccloud.json
+++ b/ccloud-prometheus-grafana/assets/grafana/provisioning/dashboards/ccloud.json
@@ -40,7 +40,7 @@
       "type": "row"
     },
     {
-      "datasource": null,
+      "datasource": "Prometheus",
       "description": "The number of registered schemas",
       "fieldConfig": {
         "defaults": {
@@ -86,10 +86,7 @@
       "pluginVersion": "8.1.3",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "count (confluent_kafka_server_partition_count)",
           "format": "time_series",
@@ -105,7 +102,7 @@
       "type": "gauge"
     },
     {
-      "datasource": null,
+      "datasource": "Prometheus",
       "description": "The number of registered schemas",
       "fieldConfig": {
         "defaults": {
@@ -151,10 +148,7 @@
       "pluginVersion": "8.1.3",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "count(confluent_kafka_connect_sent_bytes)",
           "format": "time_series",
@@ -170,7 +164,7 @@
       "type": "gauge"
     },
     {
-      "datasource": null,
+      "datasource": "Prometheus",
       "description": "The number of registered schemas",
       "fieldConfig": {
         "defaults": {
@@ -216,10 +210,7 @@
       "pluginVersion": "8.1.3",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "count(confluent_kafka_ksql_streaming_unit_count)",
           "format": "time_series",
@@ -235,7 +226,7 @@
       "type": "gauge"
     },
     {
-      "datasource": null,
+      "datasource": "Prometheus",
       "description": "The number of registered schemas",
       "fieldConfig": {
         "defaults": {
@@ -281,10 +272,7 @@
       "pluginVersion": "8.1.3",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "confluent_kafka_schema_registry_schema_count",
           "format": "time_series",
@@ -845,7 +833,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": null,
+      "datasource": "Prometheus",
       "description": "The lag between a group member's committed offset and the partition's high watermark.",
       "fieldConfig": {
         "defaults": {
@@ -917,10 +905,7 @@
       "pluginVersion": "8.3.3",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "sum by (consumer_group_id, topic) (confluent_kafka_server_consumer_lag_offsets{topic=~\"$topic\", kafka_id=~\"$cluster\"})",
           "hide": false,
@@ -933,7 +918,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": null,
+      "datasource": "Prometheus",
       "description": "The average active connections to a cluster. Basic clusters limit active connections to 1000.",
       "fieldConfig": {
         "defaults": {
@@ -1005,10 +990,7 @@
       "pluginVersion": "8.3.3",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "confluent_kafka_server_successful_authentication_count{}",
           "hide": false,


### PR DESCRIPTION
**Why**

Fix prometheus datasource so that they all have the same source. Without this, it initially doesn't show all widgets.

**Expected**

It should show widgets based on one datasource, `Prometheus`.

**Observed**

It doesn't show some widgets because datasource is fixed to a uid.
