### PR TITLE
remove zookeeper_ticktime 

### DIFF
--- a/jmxexporter-prometheus-grafana/assets/grafana/provisioning/dashboards/zookeeper-cluster.json
+++ b/jmxexporter-prometheus-grafana/assets/grafana/provisioning/dashboards/zookeeper-cluster.json
@@ -809,7 +809,7 @@
       "pluginVersion": "8.1.3",
       "targets": [
         {
-          "expr": "zookeeper_minrequestlatency{job=\"zookeeper\",env=\"$env\"} * zookeeper_ticktime",
+          "expr": "zookeeper_minrequestlatency{job=\"zookeeper\",env=\"$env\"}",
           "interval": "",
           "legendFormat": "{{server_id}}:{{member_type}} ({{instance}})",
           "refId": "A"
@@ -894,7 +894,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "zookeeper_avgrequestlatency{job=\"zookeeper\",env=\"$env\"} * zookeeper_ticktime",
+          "expr": "zookeeper_avgrequestlatency{job=\"zookeeper\",env=\"$env\"}",
           "interval": "",
           "legendFormat": "{{server_id}}:{{member_type}} ({{instance}})",
           "refId": "A"
@@ -977,7 +977,7 @@
       "pluginVersion": "8.1.3",
       "targets": [
         {
-          "expr": "zookeeper_maxrequestlatency{job=\"zookeeper\",env=\"$env\"} * zookeeper_ticktime",
+          "expr": "zookeeper_maxrequestlatency{job=\"zookeeper\",env=\"$env\"}",
           "interval": "",
           "legendFormat": "{{server_id}}:{{member_type}} ({{instance}})",
           "refId": "A"


### PR DESCRIPTION
remove zookeeper_ticktime  since in version 3.3  (zk )and above the value of the request is in ms 

https://github.com/apache/zookeeper/blob/master/zookeeper-server/src/main/java/org/apache/zookeeper/server/Stats.java#L40-L51


we can probably backport to all dashboards since version 6 

https://docs.confluent.io/platform/current/installation/versions-interoperability.html#zk

