### PR TITLE
[CC prom/grafana] Bump grafana version and small other improvements

### DIFF
--- a/ccloud-prometheus-grafana/.gitignore
+++ b/ccloud-prometheus-grafana/.gitignore
@@ -1,0 +1,3 @@
+docker-compose.yaml
+assets
+

--- a/ccloud-prometheus-grafana/utils/docker-compose-template.yaml
+++ b/ccloud-prometheus-grafana/utils/docker-compose-template.yaml
@@ -9,7 +9,7 @@ services:
       - $MONITORING_STACK/assets/prometheus/prometheus-config/:/etc/prometheus
 
   grafana:
-    image: grafana/grafana:8.1.3
+    image: grafana/grafana:8.5.27
     container_name: grafana
     environment:
       - "GF_SECURITY_ADMIN_USER=admin"
@@ -22,6 +22,7 @@ services:
   
   confluent_cost_exporter:
     image: docker.io/mcolomerc/confluent-costs-exporter:latest
+    platform: linux/amd64
     container_name: confluent_cost_exporter
     environment:
     - CONFLUENT_CLOUD_API_KEY=$CONFLUENT_CLOUD_API_KEY


### PR DESCRIPTION
The main point of this PR is to bump the Grafana version of the CC Prometheus / Grafana module.
The current one contains some issues preventing panels to be refreshed properly.

I have added a specific ".gitignore" file for generated resources as well, and we need to specify the platform for the cost exporter on MacOS.