### PR TITLE
Fix: Prometheus/Grafana consumer lag group id retrieval should not use lag exporter metric

### DIFF
--- a/jmxexporter-prometheus-grafana/assets/grafana/provisioning/dashboards/kafka-consumer.json
+++ b/jmxexporter-prometheus-grafana/assets/grafana/provisioning/dashboards/kafka-consumer.json
@@ -844,7 +844,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "sum by (hostname, consumergroup, topic) (kafka_server_tenant_metrics_consumer_lag_offsets{client_id=~\"$client_id\", env=\"$env\", topic=~\"$topic\", consumergroup=~\"$consumer_group\"})",
+          "expr": "sum by (hostname, consumergroup, topic) (kafka_server_tenant_metrics_consumer_lag_offsets{env=\"$env\", topic=~\"$topic\", consumergroup=~\"$consumer_group\"})",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -950,7 +950,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "kafka_server_tenant_metrics_consumer_lag_offsets{client_id=~\"$client_id\", env=\"$env\", topic=~\"$topic\", consumergroup=~\"$consumer_group\"}",
+          "expr": "kafka_server_tenant_metrics_consumer_lag_offsets{env=\"$env\", topic=~\"$topic\", consumergroup=~\"$consumer_group\"}",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -2243,7 +2243,7 @@
           "type": "prometheus",
           "uid": "${Prometheus}"
         },
-        "definition": "label_values(kafka_consumergroup_group_lag, group)",
+        "definition": "label_values(kafka_server_tenant_metrics_consumer_lag_offsets,consumergroup)",
         "hide": 0,
         "includeAll": true,
         "label": "Group ID",
@@ -2251,7 +2251,7 @@
         "name": "consumer_group",
         "options": [],
         "query": {
-          "query": "label_values(kafka_consumergroup_group_lag, group)",
+          "query": "label_values(kafka_server_tenant_metrics_consumer_lag_offsets,consumergroup)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,


### PR DESCRIPTION
The consumer dashboard of the Prometheus/Grafana module uses a metric exported by the Consumer Lag Exporter tool.
This tool is now more or less deprecated, and we already have a dedicated dashboard for the Lag exporter.

Instead, it should use the new metric `kafka_server_tenant_metrics_consumer_lag_offsets`.

I have removed the client id in the Prometheus query as well because the client id in this metric is different from the client id retrieved using the metric `kafka_consumer_app_info`.

