### PR TITLE
Gitpod Support

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,23 @@
+image: gitpod/workspace-full
+
+# Commands that will run on workspace start
+tasks:
+  - name: Run dev-toolkit
+    before: |
+      curl -L --http1.1 https://cnfl.io/cli | sudo sh -s -- -b /usr/local/bin
+    command: |
+      cd dev-toolkit
+      ./start.sh
+
+# Ports to expose on workspace startup
+ports:
+  - port: 3000
+    name: Grafana
+    visibility: public
+  - port: 9090
+    name: Prometheus
+    visibility: public
+
+vscode:
+  extensions:
+    - ms-azuretools.vscode-docker

--- a/README.md
+++ b/README.md
@@ -141,6 +141,8 @@ For an example that showcases how to monitor Apache Kafka client applications, a
 
 # How to use with a minimal configuration: DEV-toolkit
 
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://github.com/confluentinc/jmx-monitoring-stacks/)
+
 To run a lightweight dev environment:
 
 1. `cd dev-toolkit`

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ For an example that showcases how to monitor Apache Kafka client applications, a
 
 # How to use with a minimal configuration: DEV-toolkit
 
-[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://github.com/confluentinc/jmx-monitoring-stacks/)
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/confluentinc/jmx-monitoring-stacks/)
 
 To run a lightweight dev environment:
 


### PR DESCRIPTION
Related to this issue https://github.com/confluentinc/jmx-monitoring-stacks/issues/234, will enable Gitpod by starting dev-toolkit instead cp-demo. 