### PR TITLE
Add missing podTargetLabels to prometheusExporter

### DIFF
--- a/jmxexporter-prometheus-grafana/cfk/pm-confluent.yaml
+++ b/jmxexporter-prometheus-grafana/cfk/pm-confluent.yaml
@@ -7,6 +7,12 @@ metadata:
   name: pm-confluent
 spec:
   jobLabel: platform.confluent.io/type
+  podTargetLabels:
+    - app
+    - clusterId
+    - confluent-platform
+    - platform.confluent.io/type
+    - type
   podMetricsEndpoints:
     - port: prometheus
       interval: 60s


### PR DESCRIPTION
This ensures that the target labels will be in the Prometheus metrics, 
which are needed for the dashboards.
Also adds a newline at the end of the file