### PR TITLE
add Confluent Tiered Storage profile to dev-toolkit

### DIFF
--- a/dev-toolkit/docker-compose.tieredstorage.yaml
+++ b/dev-toolkit/docker-compose.tieredstorage.yaml
@@ -1,0 +1,82 @@
+services:
+  minio:
+    image: minio/minio
+    hostname: minio
+    container_name: minio
+    profiles:
+      - tieredstorage
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    volumes:
+      - minio_storage:/data
+    environment:
+      MINIO_ROOT_USER: admin
+      MINIO_ROOT_PASSWORD: minioadmin
+    command: server --console-address ":9001" /data
+
+  kafka1:
+    depends_on:
+      - minio
+    environment:
+      KAFKA_CONFLUENT.TIER.FEATURE: true
+      KAFKA_CONFLUENT.TIER.ENABLE: true
+      KAFKA_CONFLUENT.TIER.BACKEND: S3
+      KAFKA_CONFLUENT.TIER.S3.BUCKET: democp-bucket
+      KAFKA_CONFLUENT.TIER.S3.REGION: us-east-1
+      KAFKA_CONFLUENT.TIER.S3.AWS.ENDPOINT.OVERRIDE: http://minio:9000
+      KAFKA_CONFLUENT.TIER.S3.FORCE.PATH.STYLE.ACCESS: true
+      KAFKA_CONFLUENT.TIER.S3.CRED.FILE.PATH: /tmp/minio.properties
+    volumes:
+      - $PWD/tieredstorage/minio.properties:/tmp/minio.properties
+
+  kafka2:
+    depends_on:
+      - minio
+    environment:
+      KAFKA_CONFLUENT.TIER.FEATURE: true
+      KAFKA_CONFLUENT.TIER.ENABLE: true
+      KAFKA_CONFLUENT.TIER.BACKEND: S3
+      KAFKA_CONFLUENT.TIER.S3.BUCKET: democp-bucket
+      KAFKA_CONFLUENT.TIER.S3.REGION: us-east-1
+      KAFKA_CONFLUENT.TIER.S3.AWS.ENDPOINT.OVERRIDE: http://minio:9000
+      KAFKA_CONFLUENT.TIER.S3.FORCE.PATH.STYLE.ACCESS: true
+      KAFKA_CONFLUENT.TIER.S3.CRED.FILE.PATH: /tmp/minio.properties
+    volumes:
+      - $PWD/tieredstorage/minio.properties:/tmp/minio.properties
+
+  kafka3:
+    depends_on:
+      - minio
+    environment:
+      KAFKA_CONFLUENT.TIER.FEATURE: true
+      KAFKA_CONFLUENT.TIER.ENABLE: true
+      KAFKA_CONFLUENT.TIER.BACKEND: S3
+      KAFKA_CONFLUENT.TIER.S3.BUCKET: democp-bucket
+      KAFKA_CONFLUENT.TIER.S3.REGION: us-east-1
+      KAFKA_CONFLUENT.TIER.S3.AWS.ENDPOINT.OVERRIDE: http://minio:9000
+      KAFKA_CONFLUENT.TIER.S3.FORCE.PATH.STYLE.ACCESS: true
+      KAFKA_CONFLUENT.TIER.S3.CRED.FILE.PATH: /tmp/minio.properties
+    volumes:
+      - $PWD/tieredstorage/minio.properties:/tmp/minio.properties
+
+  kafka4:
+    depends_on:
+      - minio
+    environment:
+      KAFKA_CONFLUENT.TIER.FEATURE: true
+      KAFKA_CONFLUENT.TIER.ENABLE: true
+      KAFKA_CONFLUENT.TIER.BACKEND: S3
+      KAFKA_CONFLUENT.TIER.S3.BUCKET: democp-bucket
+      KAFKA_CONFLUENT.TIER.S3.REGION: us-east-1
+      KAFKA_CONFLUENT.TIER.S3.AWS.ENDPOINT.OVERRIDE: http://minio:9000
+      KAFKA_CONFLUENT.TIER.S3.FORCE.PATH.STYLE.ACCESS: true
+      KAFKA_CONFLUENT.TIER.S3.CRED.FILE.PATH: /tmp/minio.properties
+    volumes:
+      - $PWD/tieredstorage/minio.properties:/tmp/minio.properties
+
+
+
+
+volumes:
+  minio_storage: {}

--- a/dev-toolkit/stop.sh
+++ b/dev-toolkit/stop.sh
@@ -8,6 +8,16 @@ else
     DOCKER_COMPOSE_CMD="docker compose"
 fi
 
+# get args from command line (if any) and put them in a variable
+docker_args=("$@")
+echo "docker_args: ${docker_args[@]}"
+
+# if docker_args contains tieredstorage, then create topics required for tieredstorage
+if [[ " ${docker_args[@]} " =~ " tieredstorage " ]]; then
+  echo -e "\nWaiting 3 seconds before creating democp-bucket on minio..."
+  $DOCKER_COMPOSE_CMD stop kafka1 kafka2 kafka3 kafka4 minio
+fi
+
 # Cleanup
 $DOCKER_COMPOSE_CMD \
     --profile replicator \

--- a/dev-toolkit/tieredstorage/minio.properties
+++ b/dev-toolkit/tieredstorage/minio.properties
@@ -1,0 +1,2 @@
+accessKey=admin
+secretKey=minioadmin

--- a/jmxexporter-prometheus-grafana/README.md
+++ b/jmxexporter-prometheus-grafana/README.md
@@ -232,7 +232,7 @@ To test follow the next steps:
 
 ```bash
 $ cd dev-toolkit
-$ start.sh --profile replicator
+$ start.sh --profile tieredstorage
 ```
 
 ![tiered-storage](img/tiered-storage.png)

--- a/jmxexporter-prometheus-grafana/README.md
+++ b/jmxexporter-prometheus-grafana/README.md
@@ -39,8 +39,8 @@ List of provided dashboards:
  - [Rest Proxy _(cp-demo)_](https://github.com/confluentinc/jmx-monitoring-stacks/blob/main/jmxexporter-prometheus-grafana/README.md#rest-proxy)
  - [KRaft overview _(dev-toolkit)_](https://github.com/confluentinc/jmx-monitoring-stacks/blob/main/jmxexporter-prometheus-grafana/README.md#kraft)
  - [Confluent RBAC _(cp-demo)_](https://github.com/confluentinc/jmx-monitoring-stacks/blob/main/jmxexporter-prometheus-grafana/README.md#rbac)
- - [Replicator _(dev-toolkit)_](https://github.com/confluentinc/jmx-monitoring-stacks/blob/main/jmxexporter-prometheus-grafana/README.md#replicator)
- - [Tiered Storage](https://github.com/confluentinc/jmx-monitoring-stacks/blob/main/jmxexporter-prometheus-grafana/README.md#tiered-storage)
+ - [Confluent Replicator _(dev-toolkit)_](https://github.com/confluentinc/jmx-monitoring-stacks/blob/main/jmxexporter-prometheus-grafana/README.md#replicator)
+ - [Confluent Tiered Storage](https://github.com/confluentinc/jmx-monitoring-stacks/blob/main/jmxexporter-prometheus-grafana/README.md#tiered-storage)
  - [Confluent Audit _(cp-demo)_](https://github.com/confluentinc/jmx-monitoring-stacks/blob/main/jmxexporter-prometheus-grafana/README.md#confluent-audit)
  - [Flink Cluster](https://github.com/confluentinc/jmx-monitoring-stacks/blob/main/jmxexporter-prometheus-grafana/README.md#flink-cluster)
 
@@ -225,6 +225,16 @@ $ start.sh --profile replicator
 
 
 ### Tiered Storage
+
+To test follow the next steps:
+
+1. Start dev-toolkit with _tieredstorage_ profile
+
+```bash
+$ cd dev-toolkit
+$ start.sh --profile replicator
+```
+
 ![tiered-storage](img/tiered-storage.png)
 
 ### Confluent Audit

--- a/jmxexporter-prometheus-grafana/assets/grafana/provisioning/dashboards/tiered-storage.json
+++ b/jmxexporter-prometheus-grafana/assets/grafana/provisioning/dashboards/tiered-storage.json
@@ -163,7 +163,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "sum(kafka_log_log_size{job=\"kafka-broker\",env=\"$env\", instance=\"$instance\"}) by (instance)",
+          "expr": "sum(kafka_log_log_size{job=\"kafka-broker\",env=\"$env\", instance=~\"$instance\"}) by (instance)",
           "format": "time_series",
           "hide": false,
           "interval": "",


### PR DESCRIPTION
To test, use **devtoolkit**:

```bash
$ cd dev-toolkit
$ start.sh --profile tieredstorage
```

It uses a bucket named _democp-bucket_ hosted on local _minio_ instance, started as a docker container.

topic _trades_ has been created using:

```bash
 --config confluent.tier.enable=true --config confluent.tier.local.hotset.ms=30000  --config segment.bytes=2000000
```

Part of issue: #261