### PR TITLE
fix: Request Handler Avg Percent panel in Kafka Cluster grafana dashb…

### DIFF
--- a/jmxexporter-prometheus-grafana/assets/grafana/provisioning/dashboards/kafka-cluster-kraft.json
+++ b/jmxexporter-prometheus-grafana/assets/grafana/provisioning/dashboards/kafka-cluster-kraft.json
@@ -3544,7 +3544,7 @@
                 "type": "prometheus",
                 "uid": "${Prometheus}"
               },
-              "expr": "1 - kafka_server_kafkarequesthandlerpool_controlplanerequesthandleravgidlepercent{job=\"kafka-broker\",env=\"$env\",instance=~\"$instance\"}",
+              "expr": "1 - kafka_server_kafkarequesthandlerpool_requesthandleravgidlepercent_oneminuterate{job=\"kafka-broker\",env=\"$env\",instance=~\"$instance\"}",
               "interval": "",
               "legendFormat": "{{instance}}",
               "refId": "A"

--- a/jmxexporter-prometheus-grafana/assets/grafana/provisioning/dashboards/kafka-cluster.json
+++ b/jmxexporter-prometheus-grafana/assets/grafana/provisioning/dashboards/kafka-cluster.json
@@ -3534,7 +3534,7 @@
                 "type": "prometheus",
                 "uid": "${Prometheus}"
               },
-              "expr": "1 - kafka_server_kafkarequesthandlerpool_controlplanerequesthandleravgidlepercent{job=\"kafka-broker\",env=\"$env\",instance=~\"$instance\"}",
+              "expr": "1 - kafka_server_kafkarequesthandlerpool_requesthandleravgidlepercent_oneminuterate{job=\"kafka-broker\",env=\"$env\",instance=~\"$instance\"}",
               "interval": "",
               "legendFormat": "{{instance}}",
               "refId": "A"

--- a/shared-assets/jmx-exporter/kafka_broker.yml
+++ b/shared-assets/jmx-exporter/kafka_broker.yml
@@ -166,8 +166,8 @@ rules:
   #   labels:
   #     "$3": "$4"
   #     attribute_name: "$5"
-  - pattern: kafka.server<type=KafkaRequestHandlerPool, name=RequestHandlerAvgIdlePercent><>OneMinuteRate
-    name: kafka_server_kafkarequesthandlerpool_requesthandleravgidlepercent_total
+  - pattern: 'kafka.server<type=KafkaRequestHandlerPool, name=RequestHandlerAvgIdlePercent><>OneMinuteRate:'
+    name: kafka_server_kafkarequesthandlerpool_requesthandleravgidlepercent_oneminuterate
     type: GAUGE
   # "kafka.server:type=*, listener=*, networkProcessor=*, clientSoftwareName=*, clientSoftwareVersion=*"
   - pattern: kafka.server<type=socket-server-metrics, clientSoftwareName=(.+), clientSoftwareVersion=(.+), listener=(.+), networkProcessor=(.+)><>connections


### PR DESCRIPTION
Replace `kafka_server_kafkarequesthandlerpool_controlplanerequesthandleravgidlepercent` with `kafka_server_kafkarequesthandlerpool_requesthandleravgidlepercent_oneminuterate` to match the corresponding jmx metric.