### PR TITLE
exporting kafka.network<type=RequestMetrics, name=DeprecatedRequestsPerSec> mbean attributes

### DIFF
--- a/jmxexporter-prometheus-grafana/assets/grafana/provisioning/dashboards/kafka-cluster.json
+++ b/jmxexporter-prometheus-grafana/assets/grafana/provisioning/dashboards/kafka-cluster.json
@@ -1841,6 +1841,212 @@
     },
     {
       "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 18
+      },
+      "id": 156,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Prometheus}"
+          },
+          "description": "Deprecated API calls that will be removed in AK 4.0 by KIP-896",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 3
+          },
+          "id": 157,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${Prometheus}"
+              },
+              "editorMode": "code",
+              "expr": "sum by (api_name, api_version) (kafka_network_requestmetrics_deprecatedrequestspersec_fiveminuterate)",
+              "instant": false,
+              "legendFormat": "{{api_name}} v{{api_version}} ",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Deprecated API Requests rate (5m)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Prometheus}"
+          },
+          "description": "Deprecated API calls that will be removed in AK 4.0 by KIP-896",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 3
+          },
+          "id": 158,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${Prometheus}"
+              },
+              "editorMode": "code",
+              "expr": "sum by (client_software_name, client_software_version) (kafka_network_requestmetrics_deprecatedrequestspersec_fiveminuterate{instance=\"$instance\", env=\"$env\",})",
+              "instant": false,
+              "legendFormat": "{{client_software_name}}:{{client_software_version}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Deprecated API Requests rate (5m) by client name:version",
+          "type": "timeseries"
+        }
+      ],
+      "title": "Deprecated API Requests rate",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
       "datasource": {
         "type": "prometheus",
         "uid": "${Prometheus}"

--- a/shared-assets/jmx-exporter/kafka_broker.yml
+++ b/shared-assets/jmx-exporter/kafka_broker.yml
@@ -27,6 +27,24 @@ blacklistObjectNames:
   - "confluent.metadata.service:type=app-info,client-id=*"
   - "confluent.metadata:type=kafkaauthstore,*"
 rules:
+  - pattern: 'kafka.network<type=RequestMetrics, name=DeprecatedRequestsPerSec, request=(.+), version=(.+), clientSoftwareName=(.+), clientSoftwareVersion=(.+)><>(Count)'
+    name: kafka_network_requestmetrics_deprecatedrequestspersec_$5
+    cache: true
+    labels:
+      api_name:  "$1"
+      api_version: "$2"
+      client_software_name: "$3"
+      client_software_version: "$4"
+
+  - pattern: 'kafka.network<type=RequestMetrics, name=DeprecatedRequestsPerSec, request=(.+), version=(.+), clientSoftwareName=(.+), clientSoftwareVersion=(.+)><>(Count|OneMinuteRate|FiveMinuteRate|FifteenMinuteRate)'
+    name: kafka_network_requestmetrics_deprecatedrequestspersec_$5
+    type: GAUGE
+    cache: true
+    labels:
+      api_name:  "$1"
+      api_version: "$2"
+      client_software_name: "$3"
+      client_software_version: "$4"
   # This rule is more specific than the next rule; it has to come before it otherwise it will never be hit
   # "kafka.server:type=*,name=*, client-id=*, topic=*, partition=*"
   - pattern: kafka.server<type=(.+), name=(.+), clientId=(.+), topic=(.+), partition=(.*)><>Value


### PR DESCRIPTION
Exposed in Kafka Dashboard a new row displaying 2 panels:

- deprecated API requests per sec rate (5min) aggregated by api request and version
- deprecated API requests per sec rate (5min) aggregated by client name and version

See attached image as an example
![DeprecatedApiRequests](https://github.com/user-attachments/assets/3ee98960-8c2a-46a8-af21-14a66fb94d9d)

<!> WARNING: initial kafka_broker.yml regex match generic kafka mbeans for Count attributes such as "kafka.network<type=RequestMetrics, name=DeprecatedRequestsPerSec, request=(.+), version=(.+), clientSoftwareName=(.+), clientSoftwareVersion=(.+)><>(Count)" so I put DeprecatedRequestsPerSec regexes at the beginning of the file, let's discuss this if you want